### PR TITLE
GBadge, better performance, class independence 

### DIFF
--- a/src/components/GBadge/GBadge.spec.ts
+++ b/src/components/GBadge/GBadge.spec.ts
@@ -19,13 +19,12 @@ describe('GBadge', () => {
       bottom: false,
       dot: false,
       'g-bg-orange-100': true,
-      'g-border-mid-grey-100': true,
       inline: false,
       left: false,
       overlap: false,
     });
     expect(wrapper.vm.badgeContainerClass).toEqual({
-      "g-badge": true,
+      'g-badge': true,
       inline: false,
       left: false,
     });
@@ -48,7 +47,6 @@ describe('GBadge', () => {
       bottom: false,
       dot: false,
       'g-bg-green-400': true,
-      'g-border-green-500': true,
       inline: false,
       left: false,
       overlap: false,
@@ -67,7 +65,7 @@ describe('GBadge', () => {
 
     // then
     expect(wrapper.vm.badgeContainerClass).toEqual({
-      "g-badge": true,
+      'g-badge': true,
       inline: true,
       left: true,
     });

--- a/src/components/GBadge/GBadge.vue
+++ b/src/components/GBadge/GBadge.vue
@@ -3,17 +3,11 @@
     :class="badgeContainerClass"
   >
     <div
-      v-if="dot"
-      :class="badgeClass"
-      :style="badgeStyle"
-    />
-    <div
-      v-else
       :class="badgeClass"
       :style="badgeStyle"
     >
       <GText
-        v-if="text"
+        v-if="!dot && text"
         variant="caption"
         :color="textColor"
       >

--- a/src/components/GBadge/GBadge.vue
+++ b/src/components/GBadge/GBadge.vue
@@ -83,7 +83,7 @@ export default {
     },
     badgeStyle () {
       return {
-        'border-color': [`var(${this.borderColor})`],
+        'border-color': [`var(--${this.borderColor})`],
       };
     },
     badgeContainerClass () {

--- a/src/components/GBadge/GBadge.vue
+++ b/src/components/GBadge/GBadge.vue
@@ -5,10 +5,12 @@
     <div
       v-if="dot"
       :class="badgeClass"
+      :style="badgeStyle"
     />
     <div
       v-else
       :class="badgeClass"
+      :style="badgeStyle"
     >
       <GText
         v-if="text"
@@ -82,8 +84,12 @@ export default {
         dot: this.dot,
         inline: this.inline,
         border: this.border && !this.dot,
-        [`g-border-${this.borderColor}`]: true,
         [`g-bg-${this.backgroundColor}`]: true,
+      };
+    },
+    badgeStyle () {
+      return {
+        'border-color': [`var(${this.borderColor})`],
       };
     },
     badgeContainerClass () {

--- a/src/components/GBadge/__snapshots__/GBadge.spec.ts.snap
+++ b/src/components/GBadge/__snapshots__/GBadge.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`GBadge should match snapshot with default style 1`] = `
   class="g-badge"
 >
   <div
-    class="badge g-border-mid-grey-100 g-bg-orange-100"
+    class="badge g-bg-orange-100"
   >
     <gtext-stub
       color="white"


### PR DESCRIPTION
Why?

Updated v-if, v-else conditions for performance.

Updated g-border-color class usage to style based var usage. Because, this component should not rely on global classes which should be imported in main app. This component should work without importing that utility classes. It takes too much space such as 20-30kb to store all the colors with classes.

Separation of Concerns

Due this princible each component should be independent. If you would like to follow this princible i will going to update each component to make it independent. 


