### PR TITLE
Remove toLocaleUpperCase from label

### DIFF
--- a/src/components/GTabs/GTabs.vue
+++ b/src/components/GTabs/GTabs.vue
@@ -151,7 +151,7 @@ export default {
     },
     label (label) {
       return label
-        ? label.toLocaleUpperCase('TR')
+        ? label
         : '';
     },
   },


### PR DESCRIPTION
Why ?

toLocaleUpperCase blocks user to use their own naming style on labels.

For example,
A user needs to use title case naming, but he/she can't do this, because of toLocaleUppercase