### PR TITLE
Fix Safari gradient button bug

### DIFF
--- a/src/components/GButton/GButton.vue
+++ b/src/components/GButton/GButton.vue
@@ -573,7 +573,7 @@ export default {
       background-image: linear-gradient(96deg,var(--purple-500),var(--blue-500));
       -webkit-background-clip: text;
       background-clip: text;
-      -webkit-text-fill-color: transparent;
+      -webkit-text-fill-color: var(--purple-500);
     }
     &:hover {
       background-image: linear-gradient(280deg,var(--blue-500),var(--purple-500));


### PR DESCRIPTION
GButton gradient variant has a bug on Safari browser.
I fixed it. 
Before:
<img width="1246" alt="Screen Shot 2021-12-31 at 10 27 12" src="https://user-images.githubusercontent.com/1132683/147809696-c844119f-e1b8-4234-9d9f-2ad3eab19abf.png">

After:
<img width="1459" alt="Screen Shot 2021-12-31 at 10 31 16" src="https://user-images.githubusercontent.com/1132683/147809844-75be77ab-e14b-4021-b754-de525ebee03d.png">

