### PR TITLE
fix(storybook): fix for code sample issues

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,14 +9,7 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
-    // {
-    //   name: '@storybook/addon-docs',
-    //   options: {
-    //     sourceLoaderOptions: {
-    //       injectStoryParameters: false,
-    //     },
-    //   },
-    // },
+    '@storybook/addon-docs',
   ],
   features: {
     postcss: false,
@@ -24,25 +17,4 @@ module.exports = {
     buildStoriesJson: true,
   },
   framework: '@storybook/web-components',
-  webpackFinal: async (config, { configType }) => {
-    config.module.rules.push({
-      test: /\.stories\.mdx?$/,
-      use: [
-        {
-          loader: require.resolve('@storybook/source-loader'),
-          options: { parser: 'js' },
-        },
-      ],
-      enforce: 'pre',
-    });
-
-    // config.module.rules.push({
-    //   test: /\.css|\.s(c|a)ss$/,
-    //   use: [{
-    //     loader: 'lit-css-loader',
-    //   }],
-    // });
-
-    return config;
-  },
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,12 +7,17 @@ setCustomElementsManifest(customElements);
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   viewMode: 'docs',
+  docs: {
+    transformSource: (source) => source
+      // Clean Lit Expression Comments
+      .replace(/<!--\?lit\$[0-9]+\$-->|<!--\??-->/g, '')
+      // Clean empty boolean attribute values
+      .replace(/=\"\"/g, ''),
+  },
   controls: {
     matchers: {
       color: /(background|color)$/i,
       date: /Date$/,
     },
   },
-}
-
-// export const decorators = [(Story) => <fwc-theme>{Story()}</fwc-theme>];
+};

--- a/src/components/gr-button/gr-button.stories.mdx
+++ b/src/components/gr-button/gr-button.stories.mdx
@@ -54,12 +54,6 @@ Primary button is used for main actions of the screens. Like a submit button in 
   </Story>
 </Canvas>
 
-```html
-<gr-button>Save</gr-button>
-
-<gr-button secondary>Save</gr-button>
-```
-
 ## Button Sizes
 
 We have 3 sizes of buttons: `large`, `medium`, `small`. Default size is `large`.
@@ -76,14 +70,6 @@ We have 3 sizes of buttons: `large`, `medium`, `small`. Default size is `large`.
   </Story>
 </Canvas>
 
-```html
-<gr-button>Confirm</gr-button>
-
-<gr-button medium>Confirm</gr-button>
-
-<gr-button small>Confirm</gr-button>
-```
-
 ## Block buttons
 
 By default buttons use size as its content needs. But you can use button with `block` mode to fill it's container.
@@ -94,11 +80,6 @@ By default buttons use size as its content needs. But you can use button with `b
     {Template.bind({})}
   </Story>
 </Canvas>
-
-
-```html
-<gr-button secondary block disabled>Fill the form</gr-button>
-```
 
 ## Reference
 


### PR DESCRIPTION
This is a workaround for the issue that I asked about here: https://stackoverflow.com/questions/71999979/storybook-web-component-code-examples-extra-comment-tags

I debugged the issue and noticed some points: Apparently empty string value for boolean attributes with a truthy value is expected in lit-html ([Check test file](https://github.com/lit/lit/blob/main/packages/lit-html/src/test/lit-html_test.ts#L1131)) Since storybook just [uses ](https://github.com/storybookjs/storybook/blob/next/app/web-components/src/client/docs/sourceDecorator.ts#L46)render[ method](https://github.com/storybookjs/storybook/blob/next/app/web-components/src/client/docs/sourceDecorator.ts#L46) of lit and reads innerHTML of the element to show code sample, this behavior is expected. But I think that doesn’t make sense. <my-element disabled=""> works but we never write this attribute like this. This is not a good decision for the place where we show code samples. I started a discussion on this on Lit Discussion Board: https://github.com/lit/lit/discussions/2814

Secondly, [Storybook tries to clean comment blocks](https://github.com/storybookjs/storybook/blob/next/app/web-components/src/client/docs/sourceDecorator.ts#L47), but it needs to be updated like [lit-html does in its tests](https://github.com/lit/lit/blob/main/packages/lit-html/src/test/test-utils/strip-markers.ts). I’m working on opening a PR for this.

You can preview the updated Storybook here: https://6267ebb4dd54f5004a65f14a-bdmqwfzkfa.chromatic.com/

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/127687/167366867-72b25be7-3f92-49a0-9741-a1492ea287b0.png">
