### PR TITLE
fix(dialog): closed dialog takes up space in layout

### DIFF
--- a/src/components/dialog/bl-dialog.css
+++ b/src/components/dialog/bl-dialog.css
@@ -1,3 +1,7 @@
+:host {
+  display: contents;
+}
+
 .container {
   --background-color: var(--bl-color-neutral-full);
 


### PR DESCRIPTION
Adds `display: contents` for dialog host element to not render anything in layout when dialog is closed.

Fixes #579 