### PR TITLE
fix(dropdown): Dropdown Group Double hr

### DIFF
--- a/src/components/dropdown/group/bl-dropdown-group.css
+++ b/src/components/dropdown/group/bl-dropdown-group.css
@@ -23,10 +23,12 @@
   padding-top: var(--bl-size-xs);
 }
 
+/*
 :host(:not(:last-child)) .dropdown-group {
   border-bottom: 1px solid var(--bl-color-neutral-lighter);
   padding-bottom: var(--bl-size-xs);
 }
+*/
 
 /*
 :host(:not([caption])) ::slotted(:first-child) {


### PR DESCRIPTION
### Issue
When using multiple dropdown groups consecutively, two separator lines appear, causing a visual inconsistency.  
Issue link: [#965](https://github.com/Trendyol/baklava/issues/965)

### My Solution
I removed the bottom border from the group separator component, ensuring that only a single clean line appears between dropdown groups and fixing the visual inconsistency.

### Preview (After Fix)

<img width="259" alt="fixed_dropdown_group" src="https://github.com/user-attachments/assets/afeb10a5-1def-49a0-acf3-43abff6d54a9" />
