### PR TITLE
feat(datepicker): add month-year-only selection

### DIFF
--- a/src/components/calendar/bl-calendar.ts
+++ b/src/components/calendar/bl-calendar.ts
@@ -58,6 +58,10 @@ export default class BlCalendar extends DatepickerCalendarMixin {
   connectedCallback() {
     super.connectedCallback();
     setDirectionProperty(this);
+
+    if (this.monthYearOnly) {
+      this._calendarView = CALENDAR_VIEWS.MONTHS;
+    }
   }
 
   get months() {
@@ -90,7 +94,7 @@ export default class BlCalendar extends DatepickerCalendarMixin {
 
   setPreviousCalendarView() {
     this.clearRangePickerStyles();
-    if (this._calendarView === CALENDAR_VIEWS.DAYS) {
+    if (this._calendarView === CALENDAR_VIEWS.DAYS && !this.monthYearOnly) {
       if (this._calendarMonth === FIRST_MONTH_INDEX) {
         this._calendarMonth = LAST_MONTH_INDEX;
         this._calendarYear -= 1;
@@ -107,7 +111,7 @@ export default class BlCalendar extends DatepickerCalendarMixin {
 
   setNextCalendarView() {
     this.clearRangePickerStyles();
-    if (this._calendarView === CALENDAR_VIEWS.DAYS) {
+    if (this._calendarView === CALENDAR_VIEWS.DAYS && !this.monthYearOnly) {
       if (this._calendarMonth === LAST_MONTH_INDEX) {
         this._calendarMonth = FIRST_MONTH_INDEX;
         this._calendarYear += 1;
@@ -123,19 +127,29 @@ export default class BlCalendar extends DatepickerCalendarMixin {
   }
 
   setCurrentCalendarView(view: CalendarView) {
-    this._calendarView = this._calendarView !== view ? view : CALENDAR_VIEWS.DAYS;
+    const defaultView = this.monthYearOnly ? CALENDAR_VIEWS.MONTHS : CALENDAR_VIEWS.DAYS;
+
+    this._calendarView = this._calendarView !== view ? view : defaultView;
     this.setHoverClass();
   }
 
   setMonthAndCalendarView(month: number) {
     this._calendarMonth = month;
-    this._calendarView = CALENDAR_VIEWS.DAYS;
-    if (this.type === CALENDAR_TYPES.RANGE) this.setHoverClass();
+
+    if (this.monthYearOnly) {
+      // In month-year only mode, selecting a month finalizes the selection
+      const date = new Date(this._calendarYear, month, 1);
+
+      this.handleDate(date);
+    } else {
+      this._calendarView = CALENDAR_VIEWS.DAYS;
+      if (this.type === CALENDAR_TYPES.RANGE) this.setHoverClass();
+    }
   }
 
   setYearAndCalendarView(year: number) {
     this._calendarYear = year;
-    this._calendarView = CALENDAR_VIEWS.DAYS;
+    this._calendarView = this.monthYearOnly ? CALENDAR_VIEWS.MONTHS : CALENDAR_VIEWS.DAYS;
     if (this.type === CALENDAR_TYPES.RANGE) this.setHoverClass();
   }
 
@@ -393,13 +407,15 @@ export default class BlCalendar extends DatepickerCalendarMixin {
           kind="neutral"
           @click="${() => this.setPreviousCalendarView()}"
         ></bl-button>
-        <bl-button
-          variant="tertiary"
-          kind="neutral"
-          class="header-text ${showMonthSelected}"
-          @click="${() => this.setCurrentCalendarView(CALENDAR_VIEWS.MONTHS)}"
-          >${this.months[this._calendarMonth].name}
-        </bl-button>
+        ${!this.monthYearOnly
+          ? html`<bl-button
+              variant="tertiary"
+              kind="neutral"
+              class="header-text ${showMonthSelected}"
+              @click="${() => this.setCurrentCalendarView(CALENDAR_VIEWS.MONTHS)}"
+              >${this.months[this._calendarMonth].name}
+            </bl-button>`
+          : html``}
         <bl-button
           variant="tertiary"
           kind="neutral"

--- a/src/components/datepicker/bl-datepicker.stories.mdx
+++ b/src/components/datepicker/bl-datepicker.stories.mdx
@@ -175,34 +175,6 @@ You can set the datepicker to month-year only mode by using the `month-year-only
   </Story>
 </Canvas>
 
-### Multiple Type Month-Year Only
-
-<Canvas>
-  <Story name="Month Year Only - Multiple"
-         args={{
-           type: 'multiple',
-           label: 'Select Multiple Months',
-           placeholder: 'Select multiple months',
-           monthYearOnly: true
-         }}>
-    {Template.bind({})}
-  </Story>
-</Canvas>
-
-### Range Type Month-Year Only
-
-<Canvas>
-  <Story name="Month Year Only - Range"
-         args={{
-           type: 'range',
-           label: 'Select Month Range',
-           placeholder: 'Select month range',
-           monthYearOnly: true
-         }}>
-    {Template.bind({})}
-  </Story>
-</Canvas>
-
 ## RTL Support
 
 The datepicker component supports RTL (Right-to-Left) text direction. You can enable RTL mode by setting the `dir` attribute and `lang` attribute on a parent element or the `html` tag.

--- a/src/components/datepicker/bl-datepicker.stories.mdx
+++ b/src/components/datepicker/bl-datepicker.stories.mdx
@@ -1,5 +1,6 @@
 import { html } from "lit";
 import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { action } from "@storybook/addon-actions";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
@@ -28,7 +29,7 @@ export const DatepickerTemplate = (args) => html`
     value=${ifDefined(args.value)}
     style=${ifDefined(args.style)}
     disabled-dates=${ifDefined(args.disabledDates)}
-    ?month-year-only=${args.monthYearOnly}>${unsafeHTML(args.content)}
+    ?month-year-only=${args.monthYearOnly}
     @bl-datepicker-change=${(e) => {
       action('bl-datepicker-change')(e)
     }}>${unsafeHTML(args.content)}

--- a/src/components/datepicker/bl-datepicker.stories.mdx
+++ b/src/components/datepicker/bl-datepicker.stories.mdx
@@ -27,7 +27,11 @@ export const DatepickerTemplate = (args) => html`
     locale=${ifDefined(args.locale)}
     value=${ifDefined(args.value)}
     style=${ifDefined(args.style)}
-    disabled-dates=${ifDefined(args.disabledDates)}>${unsafeHTML(args.content)}
+    disabled-dates=${ifDefined(args.disabledDates)}
+    ?month-year-only=${args.monthYearOnly}>${unsafeHTML(args.content)}
+    @bl-datepicker-change=${(e) => {
+      action('bl-datepicker-change')(e)
+    }}>${unsafeHTML(args.content)}
   </bl-datepicker>`
 
 
@@ -147,6 +151,52 @@ You can set min date or max date for the datepicker.
            placeholder: 'Set min and max date',
            minDate: `${new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() - 2)}`,
            maxDate: `${new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate() + 2)}`
+         }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Month and Year Only Selection
+
+You can set the datepicker to month-year only mode by using the `month-year-only` attribute. When enabled, users can only select a month and year, not a specific day.
+
+### Single Type Month-Year Only
+
+<Canvas>
+  <Story name="Month Year Only - Single"
+         args={{
+           type: 'single',
+           label: 'Select Month and Year',
+           placeholder: 'Select month and year',
+           monthYearOnly: true
+         }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Multiple Type Month-Year Only
+
+<Canvas>
+  <Story name="Month Year Only - Multiple"
+         args={{
+           type: 'multiple',
+           label: 'Select Multiple Months',
+           placeholder: 'Select multiple months',
+           monthYearOnly: true
+         }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+### Range Type Month-Year Only
+
+<Canvas>
+  <Story name="Month Year Only - Range"
+         args={{
+           type: 'range',
+           label: 'Select Month Range',
+           placeholder: 'Select month range',
+           monthYearOnly: true
          }}>
     {Template.bind({})}
   </Story>

--- a/src/components/datepicker/bl-datepicker.test.ts
+++ b/src/components/datepicker/bl-datepicker.test.ts
@@ -1,7 +1,7 @@
 import { aTimeout, expect, fixture, html } from "@open-wc/testing";
+import sinon from "sinon";
 import { BlButton, BlDatePicker } from "../../baklava";
 import { CALENDAR_TYPES } from "../calendar/bl-calendar.constant";
-import sinon from "sinon";
 import "./bl-datepicker";
 
 describe("BlDatepicker", () => {
@@ -315,5 +315,93 @@ describe("BlDatepicker", () => {
     expect(preventDefaultSpy.called).to.be.true;
 
     expect(focusSpy.called).to.be.true;
+  });
+
+  describe("Month-Year Only Mode", () => {
+    beforeEach(async () => {
+      element = await fixture<BlDatePicker>(html`
+        <bl-datepicker type="single" locale="en" month-year-only></bl-datepicker>`);
+      await element.updateComplete;
+    });
+
+    it("should pass month-year-only attribute to calendar", async () => {
+      expect(element._calendarEl?.monthYearOnly).to.be.true;
+    });
+
+    it("should format date as MM/YYYY in month-year-only mode", async () => {
+      const testDate = new Date(2024, 9, 15); // October 15, 2024
+      const formattedDate = element.formatDate(testDate);
+
+      expect(formattedDate).to.equal("10/2024");
+    });
+
+    it("should format single date selection correctly in month-year-only mode", async () => {
+      element._calendarEl._dates = [new Date(2024, 5, 1)]; // June 2024
+      element.setDatePickerInput();
+      await element.updateComplete;
+
+      expect(element._inputValue).to.equal("06/2024");
+    });
+
+    it("should format multiple date selection correctly in month-year-only mode", async () => {
+      element.type = CALENDAR_TYPES.MULTIPLE;
+      await element.updateComplete;
+
+      element._calendarEl._dates = [new Date(2024, 0, 1), new Date(2024, 1, 1)]; // Jan & Feb 2024
+      element.setFloatingDates();
+      element.setDatePickerInput();
+      await element.updateComplete;
+
+      expect(element._inputValue).to.include("01/2024");
+      expect(element._inputValue).to.include("02/2024");
+    });
+
+    it("should format range date selection correctly in month-year-only mode", async () => {
+      element.type = CALENDAR_TYPES.RANGE;
+      await element.updateComplete;
+
+      element._calendarEl._dates = [new Date(2024, 2, 1), new Date(2024, 5, 1)]; // March to June 2024
+      element.setDatePickerInput();
+      await element.updateComplete;
+
+      expect(element._inputValue).to.equal("03/2024-06/2024");
+    });
+
+    it("should open calendar in MONTHS view when month-year-only is enabled", async () => {
+      element._inputEl?.click();
+      await element.updateComplete;
+
+      expect(element._calendarEl._calendarView).to.equal("months");
+    });
+
+    it("should fire bl-datepicker-change event with first day of month in month-year-only mode", (done) => {
+      element.addEventListener("bl-datepicker-change", (event) => {
+        const customEvent = event as CustomEvent<Date[]>;
+
+        expect(customEvent.detail.length).to.equal(1);
+        expect(customEvent.detail[0].getDate()).to.equal(1);
+        done();
+      });
+
+      // Simulate month selection
+      const testDate = new Date(2024, 6, 1); // July 1, 2024
+
+      element._calendarEl._dates = [testDate];
+      element.onCalendarChange();
+    });
+
+    it("should clear datepicker correctly in month-year-only mode", async () => {
+      element._calendarEl._dates = [new Date(2024, 3, 1)]; // April 2024
+      element.setDatePickerInput();
+      await element.updateComplete;
+
+      expect(element._inputValue).to.equal("04/2024");
+
+      element.clearDatepicker();
+      await element.updateComplete;
+
+      expect(element._inputValue).to.equal("");
+      expect(element._calendarEl._dates).to.deep.equal([]);
+    });
   });
 });

--- a/src/components/datepicker/bl-datepicker.ts
+++ b/src/components/datepicker/bl-datepicker.ts
@@ -143,6 +143,9 @@ export default class BlDatepicker extends DatepickerCalendarMixin {
   }
 
   formatDate(date: Date): string {
+    if (this.monthYearOnly) {
+      return `${String(date?.getMonth() + 1).padStart(2, "0")}/${date?.getFullYear()}`;
+    }
     return `${String(date?.getDate()).padStart(2, "0")}/${String(date?.getMonth() + 1).padStart(
       2,
       "0"
@@ -222,6 +225,7 @@ export default class BlDatepicker extends DatepickerCalendarMixin {
           .value=${this.value}
           .locale=${this.locale}
           .dayRenderer=${this.dayRenderer}
+          ?month-year-only=${this.monthYearOnly}
           @bl-calendar-change="${this.onCalendarChange}"
         ></bl-calendar>
       </bl-popover>

--- a/src/mixins/datepicker-calendar-mixin/datepicker-calendar-mixin.ts
+++ b/src/mixins/datepicker-calendar-mixin/datepicker-calendar-mixin.ts
@@ -21,6 +21,12 @@ export default class DatepickerCalendarMixin extends LitElement {
   locale: string = document.documentElement.lang || "en-EN";
 
   /**
+   * Enables month and year only selection mode
+   */
+  @property({ type: Boolean, attribute: "month-year-only", reflect: true })
+  monthYearOnly = false;
+
+  /**
    * Defines the unselectable dates for calendar
    */
   protected _disabledDates: Date[] = [];


### PR DESCRIPTION
Only month and year selection feature has been added with this PR. 

There is a prop named `month-year-only` to enable this feature. When it is true user can select only month and year except day

<img width="346" height="310" alt="image" src="https://github.com/user-attachments/assets/0164e377-feaf-4f80-bae7-425835a90fea" />
<img width="364" height="305" alt="image" src="https://github.com/user-attachments/assets/1c337971-3399-48d6-8c39-7d2d6eae32c8" />
<img width="362" height="297" alt="image" src="https://github.com/user-attachments/assets/04bbee98-b5bc-4d24-ac46-f2ac070d18c2" />
