### PR TITLE
fix(input): use padding-inline for RTL support

### DIFF
--- a/src/components/input/bl-input.css
+++ b/src/components/input/bl-input.css
@@ -55,14 +55,13 @@
   gap: var(--padding-vertical);
   height: var(--height);
   border: solid var(--border-size) var(--border-color);
-  padding: 0
-    calc(
-      var(--bl-input-padding-end, var(--padding-horizontal)) - var(--label-padding) -
+  padding-block: 0;
+  padding-inline: calc(
+      var(--bl-input-padding-start, var(--padding-horizontal)) - var(--label-padding) -
         var(--border-size)
     )
-    0
     calc(
-      var(--bl-input-padding-start, var(--padding-horizontal)) - var(--label-padding) -
+      var(--bl-input-padding-end, var(--padding-horizontal)) - var(--label-padding) -
         var(--border-size)
     );
   background-color: var(--background-color);
@@ -132,7 +131,8 @@ input {
   align-self: stretch;
   outline: 0;
   border: 0;
-  padding: 0 0 0 var(--label-padding);
+  padding-block: 0;
+  padding-inline: var(--label-padding) 0;
   font: var(--input-font);
   color: var(--text-color);
   -webkit-text-fill-color: var(--text-color);


### PR DESCRIPTION
## Summary

Fixes RTL (right-to-left) language support in the input component by replacing physical padding properties with logical CSS properties.

## Changes

- Replaced `padding-left`/`padding-right` with `padding-inline` shorthand
- Updated `.input-wrapper` and `input` padding definitions
- Ensured `--bl-input-padding-start` and `--bl-input-padding-end` variables work correctly in both LTR and RTL layouts

## Testing

- ✅ Verified input padding in LTR and RTL modes
- ✅ All existing tests pass

## Breaking Changes

None