### PR TITLE
feat(input): add text-overflow ellipsis for disabled inputs

### DIFF
--- a/src/components/input/bl-input.css
+++ b/src/components/input/bl-input.css
@@ -150,6 +150,9 @@ input::-webkit-credentials-auto-fill-button {
 
 input:disabled {
   cursor: not-allowed;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 input::-webkit-calendar-picker-indicator {

--- a/src/components/input/bl-input.test.ts
+++ b/src/components/input/bl-input.test.ts
@@ -784,5 +784,21 @@ describe("bl-input", () => {
         expect(el.validity.rangeOverflow).to.be.true;
       });
     });
+
+    describe("disabled input text overflow", () => {
+      it("should apply text-overflow ellipsis to disabled input", async () => {
+        const el = await fixture<BlInput>(
+          html`<bl-input disabled value="Very long text that should be truncated with ellipsis"></bl-input>`
+        );
+        const input = el.shadowRoot?.querySelector("input");
+
+        expect(input).to.exist;
+
+        const styles = window.getComputedStyle(input!);
+        expect(styles.textOverflow).to.equal("ellipsis");
+        expect(styles.whiteSpace).to.equal("nowrap");
+        expect(styles.overflow).to.equal("hidden");
+      });
+    });
   });
 });

--- a/src/components/input/bl-input.test.ts
+++ b/src/components/input/bl-input.test.ts
@@ -795,6 +795,7 @@ describe("bl-input", () => {
         expect(input).to.exist;
 
         const styles = window.getComputedStyle(input!);
+        
         expect(styles.textOverflow).to.equal("ellipsis");
         expect(styles.whiteSpace).to.equal("nowrap");
         expect(styles.overflow).to.equal("hidden");


### PR DESCRIPTION
- Add text-overflow:ellipsis styling to disabled input elements
- Add white-space:nowrap and overflow:hidden for proper ellipsis display
- Add test case to verify ellipsis styling is applied
- Fixes #607