### PR TITLE
Fix [BUG]: Style issue - BlAccordionGroup with single child #1084 Open

### DIFF
--- a/src/components/accordion-group/bl-accordion-group.css
+++ b/src/components/accordion-group/bl-accordion-group.css
@@ -7,6 +7,9 @@
 .accordion-group ::slotted(bl-accordion:first-child) {
   --bl-accordion-radius-bottom-right: 0;
   --bl-accordion-radius-bottom-left: 0;
+}
+
+.accordion-group ::slotted(bl-accordion:first-child:not(:last-child)) {
   --bl-accordion-border-bottom: 0;
 }
 


### PR DESCRIPTION
This PR fixes a styling bug reported in #1084 by [TaylanDurmaz](https://github.com/TaylanDurmaz) .
The fix ensures that when the first BIAccordion child in a BIAccordionGroup is not also the last child, the bottom border is removed by setting `--bl-accordion-border-bottom: 0.` As a result, this fix handles the border issue for BIAccordionGroup with single child because if BIAccordionGroup has only single  BIAccordionGroup child, its child bottom border would appear.
Fixes #1084

