### PR TITLE
fix: add Turkish localization to pagination buttons #1152

### DIFF
--- a/src/components/pagination/bl-pagination.ts
+++ b/src/components/pagination/bl-pagination.ts
@@ -218,7 +218,7 @@ export default class BlPagination extends LitElement {
           kind="neutral"
           icon="arrow_left"
           class="previous"
-          label="Previous"
+          label=${msg("Previous", { desc: "bl-pagination: previous button" })}
           ?disabled=${this.currentPage === 1}
         ></bl-button>
         <ul class="page-list">
@@ -232,7 +232,7 @@ export default class BlPagination extends LitElement {
           kind="neutral"
           icon="arrow_right"
           class="next"
-          label="Next"
+          label=${msg("Next", { desc: "bl-pagination: next button" })}
           ?disabled=${this.currentPage === this._getLastPage()}
         ></bl-button>
       </div>

--- a/translations/tr.xlf
+++ b/translations/tr.xlf
@@ -57,6 +57,16 @@
   <target>Veri bulunamadı</target>
   <note from="lit-localize">bl-table-body: no data title</note>
 </trans-unit>
+<trans-unit id="s2e192b19ed15fcf6">
+  <source>Previous</source>
+  <target>Önceki</target>
+  <note from="lit-localize">bl-pagination: previous button</note>
+</trans-unit>
+<trans-unit id="sf3ff78cc329d3528">
+  <source>Next</source>
+  <target>İleri</target>
+  <note from="lit-localize">bl-pagination: next button</note>
+</trans-unit>
 </body>
 </file>
 </xliff>


### PR DESCRIPTION
## 🐛 Fixes #1152

### Problem
The pagination component's "Previous" and "Next" button labels were hardcoded in English, making the component non-localized for Turkish users.

### Solution
- Added Turkish localization support to pagination buttons
- Updated `translations/tr.xlf` with Turkish translations
- Modified `bl-pagination.ts` to use `@lit/localize`'s `msg()` function

### Changes Made
- `translations/tr.xlf`: Added 2 translation units
  - "Previous" → "Önceki"
  - "Next" → "İleri"
- `src/components/pagination/bl-pagination.ts`: Wrapped button labels with `msg()` function

### Testing
The pagination buttons now correctly display in Turkish when the application locale is set to Turkish (tr).

### Related
Closes #1152
```
