### PR TITLE
fix(table): use MutationObserver for reactive row detection

### DIFF
--- a/src/components/table/table-body/bl-table-body.test.ts
+++ b/src/components/table/table-body/bl-table-body.test.ts
@@ -1,4 +1,5 @@
-import { expect, fixture, html } from "@open-wc/testing";
+import { expect, fixture, html, elementUpdated } from "@open-wc/testing";
+import { spy } from "sinon";
 import BlTableBody from "./bl-table-body";
 
 describe("bl-table-body", () => {
@@ -40,5 +41,61 @@ describe("bl-table-body", () => {
         </td>
       </tr>
     `);
+  });
+
+  it("should switch to slot view when rows are dynamically added", async () => {
+    //given
+    const el = await fixture<BlTableBody>(html`<bl-table-body></bl-table-body>`);
+
+    //when
+    const row = document.createElement("bl-table-row");
+
+    el.appendChild(row);
+    await elementUpdated(el);
+
+    //then
+    expect(el).shadowDom.equal("<slot></slot>");
+  });
+
+  it("should switch to no-data view when all rows are dynamically removed", async () => {
+    //given
+    const el = await fixture<BlTableBody>(html`
+      <bl-table-body>
+        <bl-table-row></bl-table-row>
+      </bl-table-body>
+    `);
+
+    expect(el).shadowDom.equal("<slot></slot>");
+
+    //when
+    el.querySelector("bl-table-row")!.remove();
+    await elementUpdated(el);
+
+    //then
+    expect(el).shadowDom.equal(`
+      <tr class="no-data-row">
+        <td class="no-data-cell" colspan="999">
+          <slot name="no-data">
+            <div class="default-no-data">
+              <bl-icon name="info"></bl-icon>
+              <p class="title">No data available</p>
+              <p class="subtitle">There are currently no records to display.</p>
+            </div>
+          </slot>
+        </td>
+      </tr>
+    `);
+  });
+
+  it("should clean up MutationObserver on disconnect", async () => {
+    //given
+    const el = await fixture<BlTableBody>(html`<bl-table-body></bl-table-body>`);
+    const disconnectSpy = spy(el["_mutationObserver"]!, "disconnect");
+
+    //when
+    el.remove();
+
+    //then
+    expect(disconnectSpy).to.have.been.calledOnce;
   });
 });

--- a/src/components/table/table-body/bl-table-body.ts
+++ b/src/components/table/table-body/bl-table-body.ts
@@ -1,5 +1,5 @@
 import { html, LitElement, TemplateResult } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import { CSSResultGroup } from "lit/development";
 import { msg } from "@lit/localize";
 import "../../icon/bl-icon";
@@ -25,8 +25,13 @@ export default class BlTableBody extends LitElement {
     return this.closest<BlTable>(blTableTag);
   }
 
-  private get hasTableRows() {
-    return this.querySelector("bl-table-row") !== null;
+  @state()
+  private hasTableRows = false;
+
+  private _mutationObserver: MutationObserver | null = null;
+
+  private _checkTableRows() {
+    this.hasTableRows = this.querySelector("bl-table-row") !== null;
   }
 
   connectedCallback(): void {
@@ -34,6 +39,16 @@ export default class BlTableBody extends LitElement {
     if (!this._table) {
       console.warn("bl-table-body is designed to be used inside a bl-table", this);
     }
+
+    this._checkTableRows();
+    this._mutationObserver = new MutationObserver(() => this._checkTableRows());
+    this._mutationObserver.observe(this, { childList: true });
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._mutationObserver?.disconnect();
+    this._mutationObserver = null;
   }
 
   render(): TemplateResult {


### PR DESCRIPTION
Replace synchronous getter-based row detection with a MutationObserver-backed `@state()` property to ensure the component reactively re-renders when bl-table-row elements are dynamically added or removed