### PR TITLE
fix(react): replace React.lazy with synchronous createComponent in Re…

### DIFF
--- a/cemPlugins/generateReactExports.js
+++ b/cemPlugins/generateReactExports.js
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
 import { pascalCase } from "pascal-case";
 import { format } from "prettier";
-import { resolveFilePath } from "./utils/resolveFilePath.js";
+import { resolveImportPath } from "./utils/resolveFilePath.js";
 import { resolveParsedType } from "./utils/resolveParsedType.js";
 
 const prettierConfig = JSON.parse(readFileSync(".prettierrc.json", "utf-8"));
@@ -26,16 +26,17 @@ export function generateReactExports() {
         throw new Error("Component not found!");
       }
 
-      const componentsCode = components
+      const resolved = components
         .map(([el, path]) => resolveComponent(el, path))
-        .filter(c => !!c[0])
-        .join("\n");
+        .filter(c => !!c);
+
+      const importStatements = resolved.map(c => c.importStatement).join("\n");
+      const componentBlocks = resolved.map(c => c.componentCode).join("\n");
 
       const code = `import React from "react";
 import { type EventName, createComponent } from "@lit-labs/react";
-
-type Constructor<T> = { new (): T };
-${componentsCode}`;
+${importStatements}
+${componentBlocks}`;
 
       const formattedCode = format(code, Object.assign(prettierConfig, { parser: "typescript" }));
       const outputPath = "./src";
@@ -48,28 +49,31 @@ ${componentsCode}`;
 /**
  * @param el {import("custom-elements-manifest").MixinDeclaration}
  * @param path string
- * @return string
+ * @return {{importStatement: string, componentCode: string} | null}
  */
 function resolveComponent(el, path) {
-  const resolvedPath = resolveFilePath(path, "default", "./");
+  if (!el) return null;
+
+  const importPath = resolveImportPath(path, "./");
+  const elementImportName = `${el.name}Element`;
   const { exportCodes, fieldCodes } = resolveEvents(el.events, el.name);
 
-  return `
-export type ${el.name} = ${resolvedPath};
+  const importStatement = `import ${elementImportName} from "${importPath}";`;
+
+  const componentCode = `
+export type ${el.name} = ${elementImportName};
 ${exportCodes}
 
 ${el.jsDoc || ""}
-export const ${el.name} = React.lazy(() =>
-  customElements.whenDefined("${el.tagName}").then(() => ({
-    default: createComponent({
-      react: React,
-      displayName: "${el.name}",
-      tagName: "${el.tagName}",
-      elementClass: customElements.get("${el.tagName}") as Constructor<${resolvedPath}>,
-      ${fieldCodes ? `events: {${fieldCodes}}` : ""}
-    })
-  }))
-);`;
+export const ${el.name} = createComponent({
+  react: React,
+  displayName: "${el.name}",
+  tagName: "${el.tagName}",
+  elementClass: ${elementImportName},
+  ${fieldCodes ? `events: {${fieldCodes}}` : ""}
+});`;
+
+  return { importStatement, componentCode };
 }
 
 /**

--- a/cemPlugins/utils/resolveFilePath.js
+++ b/cemPlugins/utils/resolveFilePath.js
@@ -7,8 +7,18 @@ import { relative } from "path";
  * @returns {string}
  */
 export function resolveFilePath(filePath, typeName, replace = "<rootPath>/") {
-  const relToProject = relative(process.cwd(), filePath)
+  const relToProject = resolveImportPath(filePath, replace);
+  return `import("${relToProject}").${typeName}`;
+}
+
+/**
+ * @param filePath
+ * @param replace
+ * @returns {string}
+ */
+export function resolveImportPath(filePath, replace = "<rootPath>/") {
+  return relative(process.cwd(), filePath)
+    .replace(/\\/g, "/")
     .replace(/\.ts$/, "")
     .replace(/^src\//, replace);
-  return `import("${relToProject}").${typeName}`;
 }


### PR DESCRIPTION
React wrappers in `baklava-react.ts` were using `React.lazy()` + `customElements.whenDefined()` to create component wrappers. `React.lazy` **always** suspends on the first render, triggering the nearest `<Suspense>` fallback and causing a visible UI flash/blink even when the custom element is already registered.

This PR replaces the lazy pattern with direct ES module imports and synchronous `createComponent()` calls. The `@customElement` decorator in each component file registers the element as a side-effect of the import, guaranteeing `elementClass` is defined before `createComponent` accesses it.

### Before (causes suspension):
```ts
export const BlButton = React.lazy(() =>
  customElements.whenDefined("bl-button").then(() => ({
    default: createComponent({
      elementClass: customElements.get("bl-button"),
      ...
    })
  }))
);
```

### After (synchronous, no flash):
```ts
import BlButtonElement from "./components/button/bl-button";

export const BlButton = createComponent({
  elementClass: BlButtonElement,
  ...
});
```

### Benefits
- **No UI flash** - components render synchronously on first mount, no Suspense fallback triggered
- **No race conditions** - ES module evaluation order guarantees element registration before `createComponent()` runs
- **Tree-shakeable** - only imported components are bundled by the consumer
- **Simpler consumer API** - consumers no longer need a separate `import '@trendyol/baklava'` side-effect import when using React wrappers

### Changed files
- `cemPlugins/generateReactExports.js` - updated generator to emit direct imports and synchronous `createComponent()` calls
- `cemPlugins/utils/resolveFilePath.js` - extracted `resolveImportPath()` utility for raw import paths

## Checklist
- [ ] I have added test cases for this feature
- [ ] I have updated the documentation (if necessary)

Fixes #1171