### PR TITLE
fix(select): prevent duplicate option registration and incorrect unregistration

### DIFF
--- a/src/components/select/bl-select.test.ts
+++ b/src/components/select/bl-select.test.ts
@@ -1315,6 +1315,39 @@ describe("bl-select", () => {
     });
   });
 
+  describe("option registration", () => {
+    it("should not register the same option twice", async () => {
+      const el = await fixture<BlSelect>(html`<bl-select>
+        <bl-select-option value="1">Option 1</bl-select-option>
+        <bl-select-option value="2">Option 2</bl-select-option>
+      </bl-select>`);
+
+      const option = el.options[0];
+
+      expect(el.options.length).to.equal(2);
+
+      el.registerOption(option);
+
+      expect(el.options.length).to.equal(2);
+    });
+
+    it("should not remove wrong option when unregistering an option not in the list", async () => {
+      const el = await fixture<BlSelect>(html`<bl-select>
+        <bl-select-option value="1">Option 1</bl-select-option>
+        <bl-select-option value="2">Option 2</bl-select-option>
+      </bl-select>`);
+
+      expect(el.options.length).to.equal(2);
+
+      const orphanOption = document.createElement("bl-select-option") as BlSelectOption;
+
+      orphanOption.value = "3";
+      el.unregisterOption(orphanOption);
+
+      expect(el.options.length).to.equal(2);
+    });
+  });
+
   describe("dropdown icon behavior", () => {
     it("should toggle popover when closed dropdown icon is clicked", async () => {
       const el = await fixture<BlSelect>(html`<bl-select>

--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -844,6 +844,8 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
    * @param option BlSelectOption reference to be registered
    */
   registerOption(option: BlSelectOption<ValueType>) {
+    if (this._connectedOptions.includes(option)) return;
+
     this._connectedOptions.push(option);
 
     if (option.selected) {
@@ -866,7 +868,11 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
    * @param option BlSelectOption reference to be unregistered
    */
   unregisterOption(option: BlSelectOption<ValueType>) {
-    this._connectedOptions.splice(this._connectedOptions.indexOf(option), 1);
+    const index = this._connectedOptions.indexOf(option);
+
+    if (index === -1) return;
+
+    this._connectedOptions.splice(index, 1);
   }
 }
 


### PR DESCRIPTION
## Summary
  - Add duplicate guard to `registerOption` to prevent the same option from being pushed to `_connectedOptions` multiple times
  - Add `indexOf === -1` guard to `unregisterOption` to prevent `splice(-1, 1)` from silently removing the last element in the array
  - These two bugs caused frameworks like Svelte (that detach/reattach DOM elements during rendering) to display duplicate selected labels in single-select mode

  Fixes #1186

  ## Test plan
  - [x] Add test: same option cannot be registered twice
  - [x] Add test: unregistering an option not in the list does not remove existing options
  - [x] All existing 85 tests pass across Chromium, Firefox, and WebKit