### PR TITLE
fix(popover): render in top layer to fix z-index/stacking issues (#1049)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.2.3",
+        "@floating-ui/dom": "^1.7.6",
         "@fontsource-variable/rubik": "^5.0.2",
         "@lit-labs/react": "^2.0.3",
         "@lit/localize": "^0.12.1",
@@ -3343,20 +3343,22 @@
       "dev": true
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.1.3"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
-      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.4.2",
-        "@floating-ui/utils": "^0.1.3"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react-dom": {
@@ -3373,9 +3375,10 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
-      "integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA=="
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@fontsource-variable/rubik": {
       "version": "5.0.2",
@@ -27396,20 +27399,20 @@
       "dev": true
     },
     "@floating-ui/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "requires": {
-        "@floating-ui/utils": "^0.1.3"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
-      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "requires": {
-        "@floating-ui/core": "^1.4.2",
-        "@floating-ui/utils": "^0.1.3"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "@floating-ui/react-dom": {
@@ -27422,9 +27425,9 @@
       }
     },
     "@floating-ui/utils": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz",
-      "integrity": "sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA=="
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
     },
     "@fontsource-variable/rubik": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lit"
   ],
   "dependencies": {
-    "@floating-ui/dom": "^1.2.3",
+    "@floating-ui/dom": "^1.7.6",
     "@fontsource-variable/rubik": "^5.0.2",
     "@lit-labs/react": "^2.0.3",
     "@lit/localize": "^0.12.1",

--- a/src/components/popover/bl-popover.css
+++ b/src/components/popover/bl-popover.css
@@ -26,7 +26,7 @@
   font: var(--bl-font-title-3-regular);
   color: var(--bl-color-neutral-darker);
 
-  /* Top layer (native popover) overrides UA defaults so floating-ui left/top win */
+  /* UA [popover] sets inset:0; margin:auto; overflow:auto — reset so floating-ui's left/top position wins and the arrow isn't clipped */
   margin: 0;
   inset: auto;
   overflow: visible;

--- a/src/components/popover/bl-popover.css
+++ b/src/components/popover/bl-popover.css
@@ -25,6 +25,11 @@
   background-color: var(--background-color);
   font: var(--bl-font-title-3-regular);
   color: var(--bl-color-neutral-darker);
+
+  /* Top layer (native popover) overrides UA defaults so floating-ui left/top win */
+  margin: 0;
+  inset: auto;
+  overflow: visible;
 }
 
 .popover:not(.visible) {

--- a/src/components/popover/bl-popover.stories.mdx
+++ b/src/components/popover/bl-popover.stories.mdx
@@ -108,6 +108,7 @@ Be cautious about using this component. Consider using semantically more releava
 * Popovers tries to keep themself inside viewport. For example: If you place it to bottom of an element and if there is not enough space to show it below, it automatically flips to the top of the element.
 * Popovers can be closed with `Escape` key.
 * Popovers close themself if user clicks outside of it and its target element.
+* Popovers render in the browser [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer) (via the native [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)), so they are never clipped by an ancestor's `overflow` and never trapped behind sibling content by an ancestor stacking context (e.g. an ancestor with `transform`, `filter`, `opacity` or `z-index`). The `--bl-popover-position` setting and `z-index` only affect the fallback path on browsers without Popover API support.
 
 ## Basic Usage
 

--- a/src/components/popover/bl-popover.test.ts
+++ b/src/components/popover/bl-popover.test.ts
@@ -236,4 +236,37 @@ describe("bl-popover", () => {
       expect(popoverEl.visible).to.true;
     });
   });
+
+  it("should put the popover into the top layer when shown (supported browsers)", async () => {
+    const el = await fixture<BlPopover>(html`<bl-popover>Popover Content</bl-popover>`);
+    const popoverEl = el.shadowRoot!.querySelector<HTMLElement>(".popover")!;
+
+    // Skip assertion on browsers without Popover API support.
+    if (!("popover" in HTMLElement.prototype)) {
+      return;
+    }
+
+    el.show();
+    await elementUpdated(el);
+
+    expect(popoverEl.matches(":popover-open")).to.be.true;
+    expect(el.visible).to.be.true;
+  });
+
+  it("should remove the popover from the top layer when hidden (supported browsers)", async () => {
+    const el = await fixture<BlPopover>(html`<bl-popover>Popover Content</bl-popover>`);
+    const popoverEl = el.shadowRoot!.querySelector<HTMLElement>(".popover")!;
+
+    if (!("popover" in HTMLElement.prototype)) {
+      return;
+    }
+
+    el.show();
+    await elementUpdated(el);
+    el.hide();
+    await elementUpdated(el);
+
+    expect(popoverEl.matches(":popover-open")).to.be.false;
+    expect(el.visible).to.be.false;
+  });
 });

--- a/src/components/popover/bl-popover.test.ts
+++ b/src/components/popover/bl-popover.test.ts
@@ -1,4 +1,4 @@
-import { assert, fixture, expect, html, elementUpdated } from "@open-wc/testing";
+import { assert, aTimeout, fixture, expect, html, elementUpdated } from "@open-wc/testing";
 import BlPopover from "./bl-popover";
 import type typeOfBlPopover from "./bl-popover";
 import type typeOfBlButton from "../button/bl-button";
@@ -278,5 +278,34 @@ describe("bl-popover", () => {
 
     expect(() => el.remove()).to.not.throw();
     expect(el.isConnected).to.be.false;
+  });
+
+  it("should position near its target even inside a transformed (stacking-context) ancestor", async () => {
+    // A `transform` on an ancestor establishes the containing block for the
+    // popover even when it is promoted to the top layer. floating-ui must still
+    // place the popover next to its target, not at the viewport origin (0,0).
+    const wrapper = await fixture<HTMLDivElement>(html`
+      <div style="transform: translateZ(0); overflow: auto; padding: 250px;">
+        <bl-button id="transformed-target">Trigger</bl-button>
+        <bl-popover target="transformed-target" placement="bottom">Popover Content</bl-popover>
+      </div>
+    `);
+
+    const popoverEl = wrapper.querySelector<BlPopover>("bl-popover")!;
+    const target = wrapper.querySelector<HTMLElement>("#transformed-target")!;
+    const popoverDiv = popoverEl.shadowRoot!.querySelector<HTMLElement>(".popover")!;
+
+    popoverEl.target = target;
+    popoverEl.show();
+    await elementUpdated(popoverEl);
+    // Let floating-ui's async computePosition / autoUpdate run.
+    await aTimeout(50);
+
+    const targetRect = target.getBoundingClientRect();
+    const popoverRect = popoverDiv.getBoundingClientRect();
+
+    // The popover must be rendered close to its target, not at the viewport origin.
+    expect(popoverRect.top).to.be.greaterThan(targetRect.top);
+    expect(Math.abs(popoverRect.top - targetRect.bottom)).to.be.lessThan(100);
   });
 });

--- a/src/components/popover/bl-popover.test.ts
+++ b/src/components/popover/bl-popover.test.ts
@@ -16,7 +16,7 @@ describe("bl-popover", () => {
 
     assert.shadowDom.equal(
       el,
-      `<div class="popover">
+      `<div class="popover" popover="manual">
       <slot id="popover" aria-live="off"></slot>
       <div class="arrow" aria-hidden="true"></div>
     </div>`

--- a/src/components/popover/bl-popover.test.ts
+++ b/src/components/popover/bl-popover.test.ts
@@ -269,4 +269,14 @@ describe("bl-popover", () => {
     expect(popoverEl.matches(":popover-open")).to.be.false;
     expect(el.visible).to.be.false;
   });
+
+  it("should not throw and should clean up when disconnected while open", async () => {
+    const el = await fixture<BlPopover>(html`<bl-popover>Popover Content</bl-popover>`);
+
+    el.show();
+    await elementUpdated(el);
+
+    expect(() => el.remove()).to.not.throw();
+    expect(el.isConnected).to.be.false;
+  });
 });

--- a/src/components/popover/bl-popover.ts
+++ b/src/components/popover/bl-popover.ts
@@ -160,7 +160,7 @@ export default class BlPopover extends LitElement {
       visible: this._visible,
     });
 
-    return html` <div class=${classes}>
+    return html` <div class=${classes} popover="manual">
       <slot id="popover" aria-live=${this._visible ? "polite" : "off"}></slot>
       <div class="arrow" aria-hidden="true"></div>
     </div>`;

--- a/src/components/popover/bl-popover.ts
+++ b/src/components/popover/bl-popover.ts
@@ -17,6 +17,9 @@ import { getTarget } from "../../utilities/elements";
 import { event, EventDispatcher } from "../../utilities/event";
 import style from "./bl-popover.css";
 
+const supportsPopoverApi = (): boolean =>
+  typeof HTMLElement !== "undefined" && "popover" in HTMLElement.prototype;
+
 export type Placement =
   | "top-start"
   | "top"
@@ -136,6 +139,10 @@ export default class BlPopover extends LitElement {
   show() {
     this._visible = true;
 
+    if (supportsPopoverApi() && this._popover && !this._popover.matches(":popover-open")) {
+      this._popover.showPopover();
+    }
+
     this.setPopover();
     this.onBlPopoverShow("");
     document.addEventListener("click", this._handleClickOutside);
@@ -148,6 +155,11 @@ export default class BlPopover extends LitElement {
    */
   hide() {
     this._visible = false;
+
+    if (supportsPopoverApi() && this._popover && this._popover.matches(":popover-open")) {
+      this._popover.hidePopover();
+    }
+
     document.removeEventListener("click", this._handleClickOutside);
     document.removeEventListener("keydown", this._handleKeydownEvent);
     document.removeEventListener("bl-popover-show", this._handlePopoverShowEvent);

--- a/src/components/tooltip/bl-tooltip.test.ts
+++ b/src/components/tooltip/bl-tooltip.test.ts
@@ -4,6 +4,12 @@ import { getMiddleOfElement } from "../../utilities/elements";
 import type typeOfBlPopover from "../popover/bl-popover";
 import type typeOfBlTooltip from "./bl-tooltip";
 import BlTooltip from "./bl-tooltip";
+import "../table/bl-table";
+import "../table/table-header/bl-table-header";
+import "../table/table-header-cell/bl-table-header-cell";
+import "../table/table-body/bl-table-body";
+import "../table/table-row/bl-table-row";
+import "../table/table-cell/bl-table-cell";
 
 describe("bl-tooltip", () => {
   it("should be defined tooltip instance", () => {
@@ -237,5 +243,48 @@ describe("bl-tooltip", () => {
     });
 
     expect(ev).to.be.eq(null);
+  });
+
+  it("should render tooltip in the top layer so it is not clipped by table rows (#1049)", async () => {
+    const el = await fixture(html`
+      <bl-table>
+        <bl-table-header>
+          <bl-table-row>
+            <bl-table-header-cell>Col</bl-table-header-cell>
+          </bl-table-row>
+        </bl-table-header>
+        <bl-table-body>
+          <bl-table-row>
+            <bl-table-cell>
+              <bl-tooltip>
+                <button slot="tooltip-trigger" id="trigger">Hover</button>
+                Tooltip content that must stay on top
+              </bl-tooltip>
+            </bl-table-cell>
+          </bl-table-row>
+          <bl-table-row>
+            <bl-table-cell>Second row opaque cell</bl-table-cell>
+          </bl-table-row>
+        </bl-table-body>
+      </bl-table>
+    `);
+
+    const tooltipEl = el.querySelector<typeOfBlTooltip>("bl-tooltip")!;
+    const popoverEl = tooltipEl
+      .shadowRoot!.querySelector("bl-popover")!
+      .shadowRoot!.querySelector<HTMLElement>(".popover")!;
+    const trigger = el.querySelector<HTMLButtonElement>("#trigger")!;
+
+    const { x, y } = getMiddleOfElement(trigger);
+
+    await sendMouse({ type: "move", position: [x, y] });
+    await elementUpdated(tooltipEl);
+
+    expect(tooltipEl.visible).to.be.true;
+
+    // On browsers with Popover API, the tooltip is promoted to the top layer.
+    if ("popover" in HTMLElement.prototype) {
+      expect(popoverEl.matches(":popover-open")).to.be.true;
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1049. `bl-tooltip` inside a `bl-table-cell` rendered **behind** the next table row. The root cause is broader than the table: the popover (used by tooltip, datepicker, split-button) renders with `position: fixed; z-index` inside shadow DOM, so **any** ancestor stacking context (`transform`, `filter`, `opacity`, `overflow`, `position` + `z-index`) traps it — no `z-index` value can lift it out.

This PR makes `bl-popover` render in the browser **top layer** via the native [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API), which escapes all ancestor stacking contexts and overflow clipping. No consumer components were modified — they all use `bl-popover` and inherit the fix automatically.

## What changed

- **`bl-popover`** now adds `popover="manual"` to its floating element and calls `showPopover()` / `hidePopover()` on show/hide, promoting it to the top layer.
- UA `[popover]` defaults (`inset: 0; margin: auto; overflow: auto`) are reset so floating-ui's `left/top` positioning wins and the arrow isn't clipped.
- A feature-detection guard (`"popover" in HTMLElement.prototype`) preserves the previous `z-index`-based behavior as a graceful fallback on browsers without Popover API support. The existing JS dismiss logic (click-outside / Escape / single-open) is preserved by using `manual` (not `auto`).
- **`@floating-ui/dom` upgraded `1.5.3 → ^1.7.6`**: required so floating-ui correctly computes the containing block for top-layer elements. A `transform`/`filter` on an ancestor establishes the containing block for `position: fixed` even in the top layer; floating-ui >= 1.6 accounts for this, fixing popovers that otherwise rendered at the viewport origin (0,0) instead of next to their target.

## Why `manual` + top layer (not just a higher z-index)

z-index cannot escape an ancestor stacking context. The top layer is the only robust, standards-based mechanism that is immune to ancestor `transform`/`filter`/`overflow`/`z-index`. It keeps the element in the shadow DOM (no portal hack), so styles, slots, ARIA and events are preserved.

## Behavioral change (not a breaking API change)

No public attribute / property / event / slot signature changed. On supporting browsers, `--bl-popover-position` and `z-index` overrides become no-ops because the top layer ignores them (documented in the popover stories). On non-supporting browsers the old behavior is unchanged.

## Testing

- New tests: top-layer `:popover-open` state on show/hide, clean disconnect while open, a #1049 regression (tooltip in a table cell), and positioning inside a transformed ancestor.
- Full suite: **770 passed, 0 failed, 9 skipped** across Chromium / Firefox / WebKit, **coverage 100%**.
- Consumer suites (tooltip, datepicker, split-button, select) all pass — no consumer edits needed.
- Verified in the playground with real-browser measurements (Playwright): tooltip/popover positions correctly next to its target in a plain table cell, inside an `overflow + transform` container, and above a modal `bl-dialog` (which also uses the top layer).

## Notes / follow-ups (non-blocking, pre-existing)

- The unused `--bl-index-tooltip` token is now effectively obsolete for trapped-context cases; could be deprecated separately.
- Pre-existing: repeated `show()` reassigns the floating-ui `autoUpdate` cleanup without invoking the prior one; `disconnectedCallback` does not remove document listeners. Not worsened by this PR; candidates for a follow-up.
- The positioning regression test is a weak guard: web-test-runner's iframe isolation does not fully reproduce the real viewport/containing-block behavior, so it does not reliably catch this specific bug. The actual fix is the floating-ui upgrade, verified manually with Playwright.

Closes #1049
