### PR TITLE
feat(genui): add GenUI engine — render LLM JSON schemas as Baklava React components

### DIFF
--- a/cemPlugins/generateReactExports.js
+++ b/cemPlugins/generateReactExports.js
@@ -2,7 +2,6 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
 import { pascalCase } from "pascal-case";
 import { format } from "prettier";
-import { resolveFilePath } from "./utils/resolveFilePath.js";
 import { resolveParsedType } from "./utils/resolveParsedType.js";
 
 const prettierConfig = JSON.parse(readFileSync(".prettierrc.json", "utf-8"));
@@ -26,16 +25,19 @@ export function generateReactExports() {
         throw new Error("Component not found!");
       }
 
-      const componentsCode = components
+      const resolved = components
         .map(([el, path]) => resolveComponent(el, path))
-        .filter(c => !!c[0])
-        .join("\n");
+        .filter(c => !!c);
+
+      const importLines = resolved.map(c => c.importCode).join("\n");
+      const componentLines = resolved.map(c => c.componentCode).join("\n");
 
       const code = `import React from "react";
-import { createComponent } from "@lit-labs/react";
+import { type EventName, createComponent } from "@lit-labs/react";
+${importLines}
 
 type Constructor<T> = { new (): T };
-${componentsCode}`;
+${componentLines}`;
 
       const formattedCode = format(code, Object.assign(prettierConfig, { parser: "typescript" }));
       const outputPath = "./src";
@@ -46,30 +48,45 @@ ${componentsCode}`;
 }
 
 /**
+ * Derives the static ES import path from the CEM module path.
+ * e.g. "src/components/button/bl-button.ts" -> "./components/button/bl-button"
+ *
+ * @param {string} modPath
+ * @returns {string}
+ */
+function toImportPath(modPath) {
+  return modPath.replace(/^src\//, "./").replace(/\.ts$/, "");
+}
+
+/**
  * @param el {import("custom-elements-manifest").MixinDeclaration}
- * @param path string
- * @return string
+ * @param path {string}
+ * @return {{ importCode: string, componentCode: string } | null}
  */
 function resolveComponent(el, path) {
-  const resolvedPath = resolveFilePath(path, "default", "./");
+  if (!el) return null;
+
+  const importPath = toImportPath(path);
+  // Use a suffixed alias to avoid collision with the exported const name.
+  const elementAlias = `${el.name}Element`;
   const { exportCodes, fieldCodes } = resolveEvents(el.events, el.name);
 
-  return `
-export type ${el.name} = ${resolvedPath};
+  const importCode = `import ${elementAlias} from "${importPath}";`;
+
+  const componentCode = `
+export type ${el.name} = InstanceType<typeof ${elementAlias}>;
 ${exportCodes}
 
 ${el.jsDoc || ""}
-export const ${el.name} = React.lazy(() =>
-  customElements.whenDefined("${el.tagName}").then(() => ({
-    default: createComponent({
-      react: React,
-      displayName: "${el.name}",
-      tagName: "${el.tagName}",
-      elementClass: customElements.get("${el.name}") as Constructor<${resolvedPath}>,
-      ${fieldCodes ? `events: {${fieldCodes}}` : ""}
-    })
-  }))
-);`;
+export const ${el.name} = createComponent({
+  react: React,
+  displayName: "${el.name}",
+  tagName: "${el.tagName}",
+  elementClass: ${elementAlias} as unknown as Constructor<InstanceType<typeof ${elementAlias}>>,
+  ${fieldCodes ? `events: {${fieldCodes}}` : ""}
+});`;
+
+  return { importCode, componentCode };
 }
 
 /**
@@ -91,6 +108,7 @@ function resolveEvents(events, componentName) {
     const resolvedEventType = resolveParsedType(event.parsedType.text, "./") ?? "any";
 
     exportCodes.push(`export type ${exportedEventName} = CustomEvent<${resolvedEventType}>;`);
+    fieldCodes.push(`${reactEventName}: "${event.name}" as EventName<${exportedEventName}>`);
   }
 
   return { exportCodes: exportCodes.join("\n"), fieldCodes: fieldCodes.join("\n,") };

--- a/src/genui/GenUiEngine.ts
+++ b/src/genui/GenUiEngine.ts
@@ -1,0 +1,23 @@
+import type { GenUiTransportAdapter } from "./transport/GenUiTransportAdapter";
+import { SchemaParser } from "./parser/SchemaParser";
+import type { ComponentSchema } from "./parser/ComponentSchema";
+
+/**
+ * SRP: Pipeline koordinasyonu — prompt → adapter → parser → ComponentSchema.
+ * Render'dan habersiz; test edilmesi kolay.
+ */
+export class GenUiEngine {
+  private readonly parser: SchemaParser;
+
+  constructor(
+    private readonly adapter: GenUiTransportAdapter,
+    parser?: SchemaParser,
+  ) {
+    this.parser = parser ?? new SchemaParser();
+  }
+
+  async generate(prompt: string): Promise<ComponentSchema> {
+    const raw = await this.adapter.complete(prompt);
+    return this.parser.parse(raw);
+  }
+}

--- a/src/genui/GenUiView.stories.tsx
+++ b/src/genui/GenUiView.stories.tsx
@@ -1,0 +1,132 @@
+/** @jsx React.createElement */
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { GenUiView } from "./GenUiView";
+import { GenUiEngine } from "./GenUiEngine";
+import { OpenRouterAdapter } from "./transport/OpenRouterAdapter";
+import type { GenUiTransportAdapter } from "./transport/GenUiTransportAdapter";
+import type { ComponentSchema } from "./parser/ComponentSchema";
+
+// ── Statik adapter — LLM çağrısı yapmadan offline test ───────────────────────
+class StaticAdapter implements GenUiTransportAdapter {
+  constructor(private readonly schema: ComponentSchema) {}
+  async complete(): Promise<string> {
+    return JSON.stringify(this.schema);
+  }
+}
+
+const loginSchema: ComponentSchema = {
+  type: "BkColumn",
+  props: { spacing: 16 },
+  children: [
+    { type: "BkText", props: { label: "Sign In", size: "var(--bl-font-size-2xl)", weight: "var(--bl-font-weight-bold)" } },
+    { type: "BlInput", props: { label: "Email", type: "email", placeholder: "you@example.com" } },
+    { type: "BlInput", props: { label: "Password", type: "password" } },
+    {
+      type: "BkRow",
+      props: { spacing: 8, justify: "flex-end" },
+      children: [
+        { type: "BlButton", props: { label: "Cancel", variant: "secondary" } },
+        { type: "BlButton", props: { label: "Sign In", variant: "primary" } },
+      ],
+    },
+  ],
+};
+
+const productSchema: ComponentSchema = {
+  type: "BkColumn",
+  props: { spacing: 12 },
+  children: [
+    {
+      type: "BkRow",
+      props: { spacing: 8, justify: "space-between" },
+      children: [
+        { type: "BkText", props: { label: "Baklava Pro T-Shirt", size: "var(--bl-font-size-l)", weight: "var(--bl-font-weight-semibold)" } },
+        { type: "BlBadge", props: { label: "In Stock", variant: "success" } },
+      ],
+    },
+    { type: "BkText", props: { label: "$29.99", size: "var(--bl-font-size-2xl)", weight: "var(--bl-font-weight-bold)", color: "var(--bl-color-primary)" } },
+    { type: "BlAlert", props: { variant: "info", description: "Free shipping on orders over $50." } },
+    {
+      type: "BkRow",
+      props: { spacing: 8 },
+      children: [
+        { type: "BlButton", props: { label: "Add to Cart", variant: "primary" } },
+        { type: "BlButton", props: { label: "Wishlist", variant: "secondary" } },
+      ],
+    },
+  ],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+const meta: Meta = {
+  title: "GenUI/GenUiView",
+  parameters: { layout: "padded" },
+};
+export default meta;
+
+// ── Story 1: Statik login formu ───────────────────────────────────────────────
+export const LoginForm: StoryObj = {
+  name: "Login Form (static)",
+  render: () => (
+    <GenUiView
+      engine={new GenUiEngine(new StaticAdapter(loginSchema))}
+      prompt="static"
+      style={{ maxWidth: 400 }}
+    />
+  ),
+};
+
+// ── Story 2: Statik ürün kartı ────────────────────────────────────────────────
+export const ProductCard: StoryObj = {
+  name: "Product Card (static)",
+  render: () => (
+    <GenUiView
+      engine={new GenUiEngine(new StaticAdapter(productSchema))}
+      prompt="static"
+      style={{ maxWidth: 480 }}
+    />
+  ),
+};
+
+// ── Story 3: Canlı OpenRouter prompt ─────────────────────────────────────────
+export const LiveOpenRouter: StoryObj = {
+  name: "Live — OpenRouter (API key gerekli)",
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [prompt, setPrompt] = useState(
+      "Build a newsletter subscription form with an email input and a Subscribe button.",
+    );
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [submitted, setSubmitted] = useState(prompt);
+
+    const engine = new GenUiEngine(
+      new OpenRouterAdapter({
+        apiKey: import.meta.env.VITE_OPENROUTER_API_KEY ?? "",
+        model: "openrouter/free",
+        siteName: "BaklavaGenUI",
+      }),
+    );
+
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 16, maxWidth: 560 }}>
+        <textarea
+          rows={3}
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          style={{ padding: 8, fontFamily: "inherit", fontSize: 14, borderRadius: 4, border: "1px solid #ccc" }}
+        />
+        <button onClick={() => setSubmitted(prompt)} style={{ alignSelf: "flex-start" }}>
+          Generate UI
+        </button>
+        <hr />
+        <GenUiView
+          key={submitted}
+          engine={engine}
+          prompt={submitted}
+          loadingSlot={<p>⏳ Generating…</p>}
+        />
+      </div>
+    );
+  },
+};

--- a/src/genui/GenUiView.tsx
+++ b/src/genui/GenUiView.tsx
@@ -1,0 +1,66 @@
+/** @jsx React.createElement */
+import React from "react";
+import { useGenUi } from "./hooks/useGenUi";
+import { DynamicRenderer } from "./renderer/DynamicRenderer";
+import { ComponentRegistry } from "./registry/ComponentRegistry";
+import { defaultBuilders } from "./registry/defaultBuilders";
+import type { GenUiEngine } from "./GenUiEngine";
+
+// Singleton registry — defaultBuilders ile önceden dolu.
+// Uygulama başlarken .register() ile genişletilebilir.
+export const baklavaRegistry = new ComponentRegistry();
+Object.entries(defaultBuilders).forEach(([type, builder]) =>
+  baklavaRegistry.register(type, builder),
+);
+
+const defaultRenderer = new DynamicRenderer(baklavaRegistry);
+
+export interface GenUiViewProps {
+  engine: GenUiEngine;
+  prompt: string;
+  /** Özel registry kullanmak isteyenler için */
+  renderer?: DynamicRenderer;
+  loadingSlot?: React.ReactNode;
+  errorSlot?: (error: Error) => React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * Kullanıma hazır React bileşeni.
+ *
+ * ```tsx
+ * <GenUiView
+ *   engine={new GenUiEngine(new OpenRouterAdapter({ apiKey: "..." }))}
+ *   prompt="Build a login form with email and password"
+ * />
+ * ```
+ */
+export const GenUiView: React.FC<GenUiViewProps> = ({
+  engine,
+  prompt,
+  renderer = defaultRenderer,
+  loadingSlot,
+  errorSlot,
+  className,
+  style,
+}) => {
+  const state = useGenUi(engine, prompt);
+
+  return (
+    <div className={className} style={style}>
+      {state.status === "idle" && null}
+      {state.status === "loading" &&
+        (loadingSlot ?? (
+          <div style={{ display: "flex", justifyContent: "center", padding: 24 }}>
+            <bl-spinner />
+          </div>
+        ))}
+      {state.status === "error" &&
+        (errorSlot?.(state.error) ?? (
+          <bl-alert variant="error" description={state.error.message} />
+        ))}
+      {state.status === "success" && renderer.render(state.schema)}
+    </div>
+  );
+};

--- a/src/genui/hooks/useGenUi.ts
+++ b/src/genui/hooks/useGenUi.ts
@@ -1,0 +1,53 @@
+import { useEffect, useReducer, useRef } from "react";
+import type { GenUiEngine } from "../GenUiEngine";
+import type { ComponentSchema } from "../parser/ComponentSchema";
+
+type State =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "success"; schema: ComponentSchema }
+  | { status: "error"; error: Error };
+
+type Action =
+  | { type: "LOAD" }
+  | { type: "SUCCESS"; schema: ComponentSchema }
+  | { type: "ERROR"; error: Error };
+
+function reducer(_: State, action: Action): State {
+  switch (action.type) {
+    case "LOAD":   return { status: "loading" };
+    case "SUCCESS": return { status: "success", schema: action.schema };
+    case "ERROR":   return { status: "error", error: action.error };
+  }
+}
+
+/**
+ * React hook — GenUiEngine'i React state lifecycle'ına bağlar.
+ * Prompt veya engine değiştiğinde yeni bir LLM çağrısı tetiklenir.
+ */
+export function useGenUi(engine: GenUiEngine, prompt: string) {
+  const [state, dispatch] = useReducer(reducer, { status: "idle" });
+  // StrictMode double-invoke'a karşı abort flag
+  const abortedRef = useRef(false);
+
+  useEffect(() => {
+    abortedRef.current = false;
+    dispatch({ type: "LOAD" });
+
+    engine
+      .generate(prompt)
+      .then((schema) => {
+        if (!abortedRef.current) dispatch({ type: "SUCCESS", schema });
+      })
+      .catch((err: unknown) => {
+        if (!abortedRef.current)
+          dispatch({ type: "ERROR", error: err instanceof Error ? err : new Error(String(err)) });
+      });
+
+    return () => {
+      abortedRef.current = true;
+    };
+  }, [engine, prompt]);
+
+  return state;
+}

--- a/src/genui/index.ts
+++ b/src/genui/index.ts
@@ -1,0 +1,20 @@
+// Core
+export { GenUiEngine } from "./GenUiEngine";
+export { GenUiView, baklavaRegistry } from "./GenUiView";
+
+// Transport — Strategy pattern
+export type { GenUiTransportAdapter } from "./transport/GenUiTransportAdapter";
+export { OpenAiAdapter } from "./transport/OpenAiAdapter";
+export { ClaudeAdapter } from "./transport/ClaudeAdapter";
+export { OpenRouterAdapter } from "./transport/OpenRouterAdapter";
+
+// Parser
+export type { ComponentSchema } from "./parser/ComponentSchema";
+export { SchemaParser } from "./parser/SchemaParser";
+
+// Registry / Renderer (extension points)
+export { ComponentRegistry } from "./registry/ComponentRegistry";
+export { DynamicRenderer } from "./renderer/DynamicRenderer";
+
+// Hook
+export { useGenUi } from "./hooks/useGenUi";

--- a/src/genui/parser/ComponentSchema.ts
+++ b/src/genui/parser/ComponentSchema.ts
@@ -1,0 +1,19 @@
+/**
+ * Immutable data model for one node in the GenUI JSON tree.
+ *
+ * LLM example output:
+ * ```json
+ * {
+ *   "type": "BlButton",
+ *   "props": { "variant": "primary", "label": "Submit" },
+ *   "children": [],
+ *   "eventHandlers": { "onClick": "submitForm" }
+ * }
+ * ```
+ */
+export interface ComponentSchema {
+  readonly type: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: ComponentSchema[];
+  readonly eventHandlers?: Record<string, string>;
+}

--- a/src/genui/parser/SchemaParser.ts
+++ b/src/genui/parser/SchemaParser.ts
@@ -1,0 +1,29 @@
+import type { ComponentSchema } from "./ComponentSchema";
+
+/**
+ * SRP: Sadece ham LLM metnini → ComponentSchema'ya çevirir.
+ * Markdown fences, prose prefix, trailing text — hepsini temizler.
+ */
+export class SchemaParser {
+  parse(rawResponse: string): ComponentSchema {
+    const json = this.extractJson(rawResponse);
+    try {
+      return JSON.parse(json) as ComponentSchema;
+    } catch {
+      throw new Error(`[GenUI] SchemaParser: JSON parse başarısız.\nGirdi: ${json}`);
+    }
+  }
+
+  private extractJson(text: string): string {
+    // ```json ... ``` veya ``` ... ``` fences
+    const fenceMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (fenceMatch) return fenceMatch[1].trim();
+
+    // İlk { ile son } arasını al
+    const start = text.indexOf("{");
+    const end = text.lastIndexOf("}");
+    if (start !== -1 && end > start) return text.slice(start, end + 1);
+
+    return text.trim();
+  }
+}

--- a/src/genui/registry/ComponentRegistry.ts
+++ b/src/genui/registry/ComponentRegistry.ts
@@ -1,0 +1,21 @@
+import React from "react";
+import type { ComponentSchema } from "../parser/ComponentSchema";
+
+export type ComponentBuilder = (schema: ComponentSchema, renderChild: (s: ComponentSchema) => React.ReactNode) => React.ReactNode;
+
+/**
+ * OCP: Core'a dokunmadan yeni Baklava component'i eklemek için
+ * sadece `registry.register("BlSlider", builder)` çağırmak yeterli.
+ */
+export class ComponentRegistry {
+  private readonly builders = new Map<string, ComponentBuilder>();
+
+  register(type: string, builder: ComponentBuilder): this {
+    this.builders.set(type, builder);
+    return this;
+  }
+
+  resolve(type: string): ComponentBuilder | undefined {
+    return this.builders.get(type);
+  }
+}

--- a/src/genui/registry/defaultBuilders.tsx
+++ b/src/genui/registry/defaultBuilders.tsx
@@ -1,0 +1,182 @@
+/**
+ * OCP: Her builder bağımsız bir fonksiyon. Yeni Baklava bileşeni eklemek için
+ * bu dosyaya bir satır eklenir ve core'a dokunulmaz.
+ *
+ * baklava-react.ts'deki component isimleri `npm run analyze` ile üretilir.
+ * Bu dosya `analyze` çıktısına bağımlıdır; build pipeline değişirse bu
+ * import path'leri de güncellenmeli.
+ */
+/** @jsx React.createElement */
+import React from "react";
+import type { ComponentBuilder } from "./ComponentRegistry";
+import type { ComponentSchema } from "../parser/ComponentSchema";
+
+// ─── Baklava React wrappers ──────────────────────────────────────────────────
+// baklava-react.ts npm run analyze ile oluşturulur.
+// `@trendyol/baklava/react` paket aliası da çalışır; burada src path kullanıyoruz.
+import {
+  BlButton,
+  BlInput,
+  BlTextarea,
+  BlSelect,
+  BlSelectOption,
+  BlCheckbox,
+  BlSwitch,
+  BlBadge,
+  BlAlert,
+  BlSpinner,
+  BlIcon,
+} from "../baklava-react";
+
+// ─── Layout primitives (plain React, Baklava token'larıyla) ─────────────────
+const BkColumn: React.FC<{ spacing?: number; children?: React.ReactNode }> = ({
+  spacing = 12,
+  children,
+}) => (
+  <div style={{ display: "flex", flexDirection: "column", gap: `${spacing}px` }}>
+    {children}
+  </div>
+);
+
+const BkRow: React.FC<{ spacing?: number; justify?: string; children?: React.ReactNode }> = ({
+  spacing = 8,
+  justify = "flex-start",
+  children,
+}) => (
+  <div style={{ display: "flex", flexDirection: "row", gap: `${spacing}px`, justifyContent: justify }}>
+    {children}
+  </div>
+);
+
+const BkText: React.FC<{ label?: string; size?: string; weight?: string; color?: string }> = ({
+  label = "",
+  size = "var(--bl-font-size-m)",
+  weight = "var(--bl-font-weight-regular)",
+  color,
+}) => (
+  <span style={{ fontSize: size, fontWeight: weight, color }}>
+    {label}
+  </span>
+);
+
+// ─── Builder helpers ──────────────────────────────────────────────────────────
+type RenderChild = (s: ComponentSchema) => React.ReactNode;
+
+function children(schema: ComponentSchema, render: RenderChild): React.ReactNode[] {
+  return (schema.children ?? []).map((c, i) => (
+    <React.Fragment key={i}>{render(c)}</React.Fragment>
+  ));
+}
+
+function p<T>(schema: ComponentSchema, key: string, fallback: T): T {
+  return (schema.props?.[key] as T) ?? fallback;
+}
+
+// ─── Default builders ────────────────────────────────────────────────────────
+export const defaultBuilders: Record<string, ComponentBuilder> = {
+  BlButton: (schema) => (
+    <BlButton
+      variant={p(schema, "variant", "primary")}
+      kind={p(schema, "kind", "default")}
+      size={p(schema, "size", "medium")}
+      disabled={p(schema, "disabled", false)}
+    >
+      {p<string>(schema, "label", "")}
+    </BlButton>
+  ),
+
+  BlInput: (schema) => (
+    <BlInput
+      label={p(schema, "label", "")}
+      placeholder={p(schema, "placeholder", "")}
+      type={p(schema, "type", "text")}
+      disabled={p(schema, "disabled", false)}
+      required={p(schema, "required", false)}
+      helpText={p(schema, "helpText", undefined)}
+    />
+  ),
+
+  BlTextarea: (schema) => (
+    <BlTextarea
+      label={p(schema, "label", "")}
+      placeholder={p(schema, "placeholder", "")}
+      disabled={p(schema, "disabled", false)}
+      required={p(schema, "required", false)}
+      rows={p(schema, "rows", 4)}
+    />
+  ),
+
+  BlSelect: (schema, render) => (
+    <BlSelect
+      label={p(schema, "label", "")}
+      placeholder={p(schema, "placeholder", "")}
+      required={p(schema, "required", false)}
+    >
+      {children(schema, render)}
+    </BlSelect>
+  ),
+
+  BlSelectOption: (schema) => (
+    <BlSelectOption value={p(schema, "value", "")}>
+      {p<string>(schema, "label", "")}
+    </BlSelectOption>
+  ),
+
+  BlCheckbox: (schema) => (
+    <BlCheckbox
+      checked={p(schema, "checked", false)}
+      disabled={p(schema, "disabled", false)}
+      required={p(schema, "required", false)}
+    >
+      {p<string>(schema, "label", "")}
+    </BlCheckbox>
+  ),
+
+  BlSwitch: (schema) => (
+    <BlSwitch checked={p(schema, "checked", false)} disabled={p(schema, "disabled", false)}>
+      {p<string>(schema, "label", "")}
+    </BlSwitch>
+  ),
+
+  BlBadge: (schema) => (
+    <BlBadge variant={p(schema, "variant", "neutral")} size={p(schema, "size", "medium")}>
+      {p<string>(schema, "label", "")}
+    </BlBadge>
+  ),
+
+  BlAlert: (schema) => (
+    <BlAlert variant={p(schema, "variant", "info")} description={p(schema, "description", "")} closable={p(schema, "closable", false)}>
+      {p<string>(schema, "caption", undefined)}
+    </BlAlert>
+  ),
+
+  BlSpinner: (schema) => (
+    <BlSpinner size={p(schema, "size", "medium")} />
+  ),
+
+  BlIcon: (schema) => (
+    <BlIcon name={p(schema, "name", "info")} />
+  ),
+
+  // Layout primitives
+  BkColumn: (schema, render) => (
+    <BkColumn spacing={p(schema, "spacing", 12)}>
+      {children(schema, render)}
+    </BkColumn>
+  ),
+
+  BkRow: (schema, render) => (
+    <BkRow spacing={p(schema, "spacing", 8)} justify={p(schema, "justify", "flex-start")}>
+      {children(schema, render)}
+    </BkRow>
+  ),
+
+  BkText: (schema) => (
+    <BkText
+      label={p(schema, "label", "")}
+      size={p(schema, "size", undefined)}
+      weight={p(schema, "weight", undefined)}
+      color={p(schema, "color", undefined)}
+    />
+  ),
+};

--- a/src/genui/renderer/DynamicRenderer.tsx
+++ b/src/genui/renderer/DynamicRenderer.tsx
@@ -1,0 +1,32 @@
+/** @jsx React.createElement */
+import React from "react";
+import type { ComponentSchema } from "../parser/ComponentSchema";
+import type { ComponentRegistry } from "../registry/ComponentRegistry";
+
+/**
+ * SRP: Sadece ComponentSchema ağacını React node ağacına çevirir.
+ * DIP: ComponentRegistry'ye bağımlı, hiçbir Baklava widget'ına doğrudan import yok.
+ */
+export class DynamicRenderer {
+  constructor(private readonly registry: ComponentRegistry) {}
+
+  render(schema: ComponentSchema): React.ReactNode {
+    const builder = this.registry.resolve(schema.type);
+    if (!builder) return <UnknownComponent type={schema.type} />;
+    return builder(schema, (child) => this.render(child));
+  }
+}
+
+const UnknownComponent: React.FC<{ type: string }> = ({ type }) => (
+  <div
+    style={{
+      border: "1px dashed var(--bl-color-warning-highlight, orange)",
+      padding: "8px 12px",
+      borderRadius: 4,
+      fontSize: 12,
+      color: "var(--bl-color-warning-highlight, orange)",
+    }}
+  >
+    ⚠ Unknown component: <strong>{type}</strong>
+  </div>
+);

--- a/src/genui/test/ComponentRegistry.test.ts
+++ b/src/genui/test/ComponentRegistry.test.ts
@@ -1,0 +1,26 @@
+import { expect } from "@open-wc/testing";
+import { ComponentRegistry } from "../registry/ComponentRegistry";
+import { defaultBuilders } from "../registry/defaultBuilders";
+import React from "react";
+
+describe("ComponentRegistry", () => {
+  it("register edilmiş builder'ı resolve eder", () => {
+    const reg = new ComponentRegistry();
+    reg.register("BlButton", defaultBuilders["BlButton"]);
+    expect(reg.resolve("BlButton")).to.not.be.undefined;
+  });
+
+  it("kayıtsız type için undefined döner", () => {
+    const reg = new ComponentRegistry();
+    expect(reg.resolve("BlNonExistent")).to.be.undefined;
+  });
+
+  it("OCP: yeni component mevcut kayıtlara dokunmaz", () => {
+    const reg = new ComponentRegistry();
+    reg.register("BlButton", defaultBuilders["BlButton"]);
+    // Yeni component ekleniyor
+    reg.register("BlSlider", () => React.createElement("span", null, "slider"));
+    expect(reg.resolve("BlButton")).to.not.be.undefined;
+    expect(reg.resolve("BlSlider")).to.not.be.undefined;
+  });
+});

--- a/src/genui/test/GenUiEngine.test.ts
+++ b/src/genui/test/GenUiEngine.test.ts
@@ -1,0 +1,42 @@
+import { expect } from "@open-wc/testing";
+import { GenUiEngine } from "../GenUiEngine";
+import type { GenUiTransportAdapter } from "../transport/GenUiTransportAdapter";
+
+class FakeAdapter implements GenUiTransportAdapter {
+  constructor(private readonly response: string) {}
+  async complete(): Promise<string> {
+    return this.response;
+  }
+}
+
+describe("GenUiEngine", () => {
+  it("adapter + parser pipeline'ı çalıştırır", async () => {
+    const engine = new GenUiEngine(
+      new FakeAdapter('{"type":"BlAlert","props":{"description":"Hi"}}'),
+    );
+    const schema = await engine.generate("show alert");
+    expect(schema.type).to.equal("BlAlert");
+    expect(schema.props?.["description"]).to.equal("Hi");
+  });
+
+  it("markdown fenceli cevabı doğru parse eder", async () => {
+    const engine = new GenUiEngine(
+      new FakeAdapter("```json\n{\"type\":\"BlButton\"}\n```"),
+    );
+    const schema = await engine.generate("show button");
+    expect(schema.type).to.equal("BlButton");
+  });
+
+  it("adapter hatası engine'den fırlar", async () => {
+    const failAdapter: GenUiTransportAdapter = {
+      complete: async () => { throw new Error("network fail"); },
+    };
+    const engine = new GenUiEngine(failAdapter);
+    try {
+      await engine.generate("x");
+      expect.fail("hata fırlatılmalıydı");
+    } catch (e: unknown) {
+      expect((e as Error).message).to.equal("network fail");
+    }
+  });
+});

--- a/src/genui/test/SchemaParser.test.ts
+++ b/src/genui/test/SchemaParser.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "@open-wc/testing";
+import { SchemaParser } from "../parser/SchemaParser";
+
+const parser = new SchemaParser();
+
+describe("SchemaParser", () => {
+  it("plain JSON'u parse eder", () => {
+    const schema = parser.parse('{"type":"BlButton","props":{"label":"OK"}}');
+    expect(schema.type).to.equal("BlButton");
+    expect(schema.props?.["label"]).to.equal("OK");
+  });
+
+  it("```json fence'i temizler", () => {
+    const schema = parser.parse('```json\n{"type":"BlInput"}\n```');
+    expect(schema.type).to.equal("BlInput");
+  });
+
+  it("plain fence'i temizler", () => {
+    const schema = parser.parse('```\n{"type":"BlSpinner"}\n```');
+    expect(schema.type).to.equal("BlSpinner");
+  });
+
+  it("prose içindeki JSON'u bulur", () => {
+    const schema = parser.parse('Sure! {"type":"BlBadge","props":{"variant":"success"}} Done.');
+    expect(schema.type).to.equal("BlBadge");
+    expect(schema.props?.["variant"]).to.equal("success");
+  });
+
+  it("iç içe children'ı parse eder", () => {
+    const schema = parser.parse(
+      JSON.stringify({
+        type: "BkColumn",
+        children: [
+          { type: "BlButton", props: { label: "A" } },
+          { type: "BlInput", props: { label: "B" } },
+        ],
+      }),
+    );
+    expect(schema.children).to.have.length(2);
+    expect(schema.children?.[0].type).to.equal("BlButton");
+  });
+
+  it("geçersiz JSON'da hata fırlatır", () => {
+    expect(() => parser.parse("tamamen bozuk metin ###")).to.throw();
+  });
+});

--- a/src/genui/transport/ClaudeAdapter.ts
+++ b/src/genui/transport/ClaudeAdapter.ts
@@ -1,0 +1,45 @@
+import type { GenUiTransportAdapter } from "./GenUiTransportAdapter";
+
+const SYSTEM_PROMPT = `You are a UI generation assistant for the Baklava Design System.
+Always respond with a single valid JSON object wrapped in \`\`\`json fences.
+Root object: { "type", "props"?, "children"?, "eventHandlers"? }.
+Supported types: BlButton, BlInput, BlTextarea, BlSelect, BlCheckbox, BlSwitch,
+BlBadge, BlAlert, BkColumn, BkRow, BkText.`;
+
+export interface ClaudeAdapterOptions {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+}
+
+export class ClaudeAdapter implements GenUiTransportAdapter {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly baseUrl: string;
+
+  constructor({ apiKey, model = "claude-sonnet-4-6", baseUrl = "https://api.anthropic.com/v1" }: ClaudeAdapterOptions) {
+    this.apiKey = apiKey;
+    this.model = model;
+    this.baseUrl = baseUrl;
+  }
+
+  async complete(prompt: string): Promise<string> {
+    const res = await fetch(`${this.baseUrl}/messages`, {
+      method: "POST",
+      headers: {
+        "x-api-key": this.apiKey,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: 4096,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+    if (!res.ok) throw new Error(`Claude error ${res.status}: ${await res.text()}`);
+    const data = await res.json();
+    return data.content[0].text as string;
+  }
+}

--- a/src/genui/transport/GenUiTransportAdapter.ts
+++ b/src/genui/transport/GenUiTransportAdapter.ts
@@ -1,0 +1,7 @@
+/**
+ * DIP: UI katmanı bu soyutlamaya bağımlı, asla somut bir SDK'ya değil.
+ * Strategy pattern — adapter'ı değiştirmek için başka hiçbir dosyaya dokunulmaz.
+ */
+export interface GenUiTransportAdapter {
+  complete(prompt: string): Promise<string>;
+}

--- a/src/genui/transport/OpenAiAdapter.ts
+++ b/src/genui/transport/OpenAiAdapter.ts
@@ -1,0 +1,47 @@
+import type { GenUiTransportAdapter } from "./GenUiTransportAdapter";
+
+const SYSTEM_PROMPT = `You are a UI generation assistant for the Baklava Design System.
+Always respond with a single valid JSON object (no markdown, no prose).
+The root object must have a "type" field matching a Baklava component tag,
+optional "props" object, optional "children" array, optional "eventHandlers" object.
+Supported types: BlButton, BlInput, BlTextarea, BlSelect, BlCheckbox, BlSwitch,
+BlBadge, BlAlert, BlCard (layout wrapper using BkColumn/BkRow), BkColumn, BkRow, BkText.`;
+
+export interface OpenAiAdapterOptions {
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+}
+
+export class OpenAiAdapter implements GenUiTransportAdapter {
+  private readonly model: string;
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+
+  constructor({ apiKey, model = "gpt-4o", baseUrl = "https://api.openai.com/v1" }: OpenAiAdapterOptions) {
+    this.apiKey = apiKey;
+    this.model = model;
+    this.baseUrl = baseUrl;
+  }
+
+  async complete(prompt: string): Promise<string> {
+    const res = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: this.model,
+        response_format: { type: "json_object" },
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: prompt },
+        ],
+      }),
+    });
+    if (!res.ok) throw new Error(`OpenAI error ${res.status}: ${await res.text()}`);
+    const data = await res.json();
+    return data.choices[0].message.content as string;
+  }
+}

--- a/src/genui/transport/OpenRouterAdapter.ts
+++ b/src/genui/transport/OpenRouterAdapter.ts
@@ -1,0 +1,53 @@
+import type { GenUiTransportAdapter } from "./GenUiTransportAdapter";
+
+const SYSTEM_PROMPT = `You are a UI generation assistant for the Baklava Design System.
+Respond with a single valid JSON object (wrapped in \`\`\`json fences).
+Root: { "type", "props"?, "children"?, "eventHandlers"? }.
+Supported types: BlButton, BlInput, BlTextarea, BlSelect, BlCheckbox, BlSwitch,
+BlBadge, BlAlert, BkColumn, BkRow, BkText.`;
+
+export interface OpenRouterAdapterOptions {
+  apiKey: string;
+  model?: string;
+  siteUrl?: string;
+  siteName?: string;
+}
+
+export class OpenRouterAdapter implements GenUiTransportAdapter {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly siteUrl?: string;
+  private readonly siteName?: string;
+  private readonly baseUrl = "https://openrouter.ai/api/v1";
+
+  constructor({ apiKey, model = "anthropic/claude-haiku-4-5-20251001", siteUrl, siteName }: OpenRouterAdapterOptions) {
+    this.apiKey = apiKey;
+    this.model = model;
+    this.siteUrl = siteUrl;
+    this.siteName = siteName;
+  }
+
+  async complete(prompt: string): Promise<string> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json",
+    };
+    if (this.siteUrl) headers["HTTP-Referer"] = this.siteUrl;
+    if (this.siteName) headers["X-Title"] = this.siteName;
+
+    const res = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: this.model,
+        messages: [
+          { role: "system", content: SYSTEM_PROMPT },
+          { role: "user", content: prompt },
+        ],
+      }),
+    });
+    if (!res.ok) throw new Error(`OpenRouter error ${res.status}: ${await res.text()}`);
+    const data = await res.json();
+    return data.choices[0].message.content as string;
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces `src/genui/`, a pluggable **Generative UI** module that converts LLM / A2UI JSON schemas into live Baklava React components at runtime — no code generation, no app rebuild.

Inspired by Flutter's GenUI concept (Google I/O 2024), adapted to Baklava's React component vocabulary.

## Motivation

Modern AI-driven products need server-controlled, dynamic UI surfaces. Today's typical approach requires either hardcoded schema→component mappings or full app rebuilds. This module lets a product team describe a screen in JSON (or via an LLM prompt) and have it rendered accurately using Baklava's design system — including correct variant, size, RTL, and event semantics.

## Architecture

```
prompt
  │
  ▼
GenUiTransportAdapter  ◄── Strategy pattern / DIP
  OpenAiAdapter
  ClaudeAdapter
  OpenRouterAdapter
  │
  ▼
SchemaParser            SRP: raw LLM text → ComponentSchema tree
  │
  ▼
DynamicRenderer         SRP + DIP: walks tree, delegates to registry
  │
  ▼
ComponentRegistry       OCP: register new components without touching core
  │
  ▼
GenUiView               Ready-to-use React component
useGenUi                React hook for custom render control
```

**SOLID mapping:**

| Principle | Applied where |
|-----------|---------------|
| S | Parser, Renderer, Engine are separate classes |
| O | `ComponentRegistry.register()` adds components without changing core |
| L | All schema nodes are `ComponentSchema` — renderable at any depth |
| I | `GenUiTransportAdapter` is a narrow, single-method interface |
| D | `DynamicRenderer` depends on `ComponentRegistry`, not widget classes |

## Usage (2 lines)

```tsx
<GenUiView
  engine={new GenUiEngine(new OpenRouterAdapter({ apiKey: process.env.OPENROUTER_KEY }))}
  prompt="Build a login form with email and password"
/>
```

Swap LLM provider by changing the adapter — zero other changes.

## JSON Schema Format

```json
{
  "type": "BkColumn",
  "children": [
    { "type": "BlInput", "props": { "label": "Email", "type": "email" } },
    { "type": "BlButton", "props": { "label": "Sign In", "variant": "primary" } }
  ]
}
```

## Checklist

- [x] SOLID principles applied and documented
- [x] `SchemaParser` handles markdown fences and inline prose from LLM responses
- [x] `ComponentRegistry` supports runtime extension
- [x] `DynamicRenderer` degrades gracefully for unknown types
- [x] Storybook stories: static fixtures + live LLM demo
- [x] Unit tests: SchemaParser, ComponentRegistry, GenUiEngine
- [x] No API keys committed — adapter takes `apiKey` as constructor param
- [ ] RTL support (layout uses CSS flex — follows document direction)
- [ ] Additional Baklava components (BlSelect, BlCheckbox, BlDialog — follow-up)