### PR TITLE
Fix/button small icon size 1209

### DIFF
--- a/src/components/button/bl-button.css
+++ b/src/components/button/bl-button.css
@@ -82,10 +82,12 @@
   inset: -4px;
 }
 
+:host .button bl-icon,
 :host ::slotted(bl-icon) {
   font-size: var(--icon-size);
 }
 
+:host([loading]) .button bl-icon,
 :host([loading]) ::slotted(bl-icon) {
   display: none;
 }

--- a/src/components/button/bl-button.test.ts
+++ b/src/components/button/bl-button.test.ts
@@ -168,6 +168,38 @@ describe("bl-button", () => {
       );
     });
   });
+
+  describe("Icon size", () => {
+    it("should apply --icon-size to default slot icon on small button", async () => {
+      const el = await fixture<typeOfBlButton>(
+        html`<bl-button size="small" icon="info"></bl-button>`
+      );
+      const icon = el.shadowRoot?.querySelector("bl-icon");
+
+      expect(icon).to.exist;
+      expect(getComputedStyle(icon!).fontSize).to.equal("14px");
+    });
+
+    it("should apply --icon-size to slotted icon on small button", async () => {
+      const el = await fixture<typeOfBlButton>(
+        html`<bl-button size="small" label="icon-button"
+          ><bl-icon name="info" slot="icon"></bl-icon
+        ></bl-button>`
+      );
+      const icon = el.querySelector('bl-icon[slot="icon"]');
+
+      expect(icon).to.exist;
+      expect(getComputedStyle(icon!).fontSize).to.equal("14px");
+    });
+
+    it("should apply --icon-size to default slot icon on medium button", async () => {
+      const el = await fixture<typeOfBlButton>(html`<bl-button icon="info">Button</bl-button>`);
+      const icon = el.shadowRoot?.querySelector("bl-icon");
+
+      expect(icon).to.exist;
+      expect(getComputedStyle(icon!).fontSize).to.equal("16px");
+    });
+  });
   describe("Events", () => {
     it("fires bl-click event on click", async () => {
       const el = await fixture<typeOfBlButton>(html`<bl-button>button</bl-button>`);


### PR DESCRIPTION
## Summary

Fixes incorrect icon sizing on `bl-button` when the icon is provided via the `icon` attribute (internal shadow DOM `bl-icon`), especially on `size="small"` buttons.

Previously, `--icon-size` was only applied to slotted icons (`::slotted(bl-icon)`). Icons rendered through the `icon` prop were not affected, so small buttons showed a 16px icon instead of the expected 14px.

## Changes

- Extend icon size CSS to target internal `.button bl-icon` in addition to slotted icons
- Hide internal icon during loading state (consistent with slotted icon behavior)
- Add unit tests covering:
  - `icon` attribute on small button → 14px
  - slotted icon on small button → 14px
  - `icon` attribute on medium button → 16px

## Motivation

`bl-button` defines `--icon-size` per size variant (`small` → `--bl-size-s`, default → `--bl-size-m`), but the style rule did not reach icons inside the shadow tree. This caused visual inconsistency between icon usage patterns.

## Test plan

- [x] `npm run test -- --files src/components/button/bl-button.test.ts`
- [x] All 26 tests pass (Chromium, Firefox, WebKit)
- [x] Verify small button with `icon="..."` renders 14px icon in Storybook

 
 Closes https://github.com/Trendyol/baklava/issues/1209