### PR TITLE
feat(datepicker): add error prop support

### DIFF
--- a/src/components/datepicker/bl-datepicker.stories.mdx
+++ b/src/components/datepicker/bl-datepicker.stories.mdx
@@ -28,6 +28,7 @@ export const DatepickerTemplate = (args) => html`
     locale=${ifDefined(args.locale)}
     value=${ifDefined(args.value)}
     style=${ifDefined(args.style)}
+    error=${ifDefined(args.error)}
     .disabledDates=${args.disabledDates}
     ?disabled=${args.disabled}
     ?month-year-only=${args.monthYearOnly}

--- a/src/components/datepicker/bl-datepicker.test.ts
+++ b/src/components/datepicker/bl-datepicker.test.ts
@@ -122,6 +122,13 @@ describe("BlDatepicker", () => {
     expect(input?.getAttribute("help-text")).to.equal("Please select a valid date.");
   });
 
+  it("should pass error prop to inner bl-input", async () => {
+    element.error = "This field is required.";
+    await element.updateComplete;
+
+    expect(element._inputEl?.error).to.equal("This field is required.");
+  });
+
   it("should close the popover after timeout", async () => {
     element._inputEl?.click();
     await element.updateComplete;

--- a/src/components/datepicker/bl-datepicker.ts
+++ b/src/components/datepicker/bl-datepicker.ts
@@ -56,6 +56,12 @@ export default class BlDatepicker extends DatepickerCalendarMixin {
   helpText: string;
 
   /**
+   * Sets input error state
+   */
+  @property({ reflect: true, type: String })
+  error: string;
+
+  /**
    * Custom function to render day cells in the calendar.
    * It receives the date as an argument and should return a TemplateResult.
    */
@@ -274,6 +280,7 @@ export default class BlDatepicker extends DatepickerCalendarMixin {
           aria-labelledby="label"
           @click=${this._togglePopover}
           help-text=${this.helpText}
+          error=${this.error}
           ?disabled=${this.disabled}
           .size=${this.size}
           .labelFixed=${this.labelFixed}


### PR DESCRIPTION
Adds `error` property to `bl-datepicker` component, passing it through to the inner `bl-input` — consistent with `bl-input`'s existing error API.

## Changes
- Added `error` reactive property to `BlDatepicker` class
- Passed `error=${this.error}` to inner `<bl-input>` in render template
- Added test verifying error prop pass-through
- Added `error` prop support to storybook template