### PR TITLE
feat(theme)!: restructure color tokens into primitive + semantic system

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -72,8 +72,8 @@ export const decorators = [
     const previewBody = document.body;
     previewBody.setAttribute('data-theme', theme);
 
-    previewBody.style.backgroundColor = 'var(--bl-color-neutral-full)';
-    previewBody.style.color = 'var(--bl-color-neutral-darkest)';
+    previewBody.style.backgroundColor = 'var(--bl-color-background-primary)';
+    previewBody.style.color = 'var(--bl-color-text-primary-hover)';
 
     try {
       if (window.parent && window.parent !== window) {

--- a/docs/customizing-baklava-theme.stories.mdx
+++ b/docs/customizing-baklava-theme.stories.mdx
@@ -120,7 +120,7 @@ For example, you can use dark theme only in header:
 In addition to setting design tokens, some of our components has their own CSS custom properties to make customisation on their style. And if you want
 you can use those custom properties in your theme definition to make all of those components in a desired style troughout your app.
 
-For example, our badge component has `--bl-badge-color` property and by default it uses `--bl-color-primary`. If you want you can use a different default
+For example, our badge component has `--bl-badge-color` property and by default it uses `--bl-color-text-brand`. If you want you can use a different default
 color for all of the badges on your app by just adding:
 
 ```css
@@ -133,7 +133,7 @@ Using design tokens here is of course also possible:
 
 ```css
 :root {
-  --bl-badge-color: var(--bl-color-success);
+  --bl-badge-color: var(--bl-color-text-success);
 }
 ```
 

--- a/docs/design-system/colors.stories.mdx
+++ b/docs/design-system/colors.stories.mdx
@@ -5,46 +5,214 @@ import { html } from 'lit';
 
 # Baklava Color Palette
 
-Baklava uses a list of defined color with some default values.
+Baklava's color system has two layers:
+
+- **Primitives** — raw, theme-agnostic color scales (`--bl-color-{family}-{step}`). These never change between light and dark themes.
+- **Semantic tokens** — role-based tokens (`--bl-color-{category}-{role}`) that reference primitives and are the ones components actually consume. Their values are re-mapped per theme (light/dark), so always prefer semantic tokens over primitives when styling.
+
+## Primitive Colors
 
 <ColorPalette>
   <ColorItem
-    title="--bl-color-primary"
-    subtitle="Primary Color"
-    colors={{ '': 'var(--bl-color-primary)', '--highlight': 'var(--bl-color-primary-highlight)', '--contrast': 'var(--bl-color-primary-contrast)' }}
+    title="--bl-color-neutral"
+    subtitle="Neutral Scale"
+    colors={{
+        '-50': 'var(--bl-color-neutral-50)',
+        '-100': 'var(--bl-color-neutral-100)',
+        '-150': 'var(--bl-color-neutral-150)',
+        '-200': 'var(--bl-color-neutral-200)',
+        '-300': 'var(--bl-color-neutral-300)',
+        '-400': 'var(--bl-color-neutral-400)',
+        '-500': 'var(--bl-color-neutral-500)',
+        '-600': 'var(--bl-color-neutral-600)',
+        '-700': 'var(--bl-color-neutral-700)',
+        '-800': 'var(--bl-color-neutral-800)',
+        '-900': 'var(--bl-color-neutral-900)',
+        '-950': 'var(--bl-color-neutral-950)',
+    }}
+  />
+  <ColorItem
+    title="--bl-color-brand"
+    subtitle="Brand Scale"
+    colors={{
+        '-50': 'var(--bl-color-brand-50)',
+        '-100': 'var(--bl-color-brand-100)',
+        '-200': 'var(--bl-color-brand-200)',
+        '-300': 'var(--bl-color-brand-300)',
+        '-400': 'var(--bl-color-brand-400)',
+        '-500': 'var(--bl-color-brand-500)',
+        '-600': 'var(--bl-color-brand-600)',
+        '-800': 'var(--bl-color-brand-800)',
+        '-900': 'var(--bl-color-brand-900)',
+        '-950': 'var(--bl-color-brand-950)',
+    }}
   />
   <ColorItem
     title="--bl-color-success"
-    subtitle="Success Color"
-    colors={{ '': 'var(--bl-color-success)', '--highlight': 'var(--bl-color-success-highlight)', '--contrast': 'var(--bl-color-success-contrast)' }}
+    subtitle="Success Scale"
+    colors={{
+        '-50': 'var(--bl-color-success-50)',
+        '-100': 'var(--bl-color-success-100)',
+        '-200': 'var(--bl-color-success-200)',
+        '-300': 'var(--bl-color-success-300)',
+        '-400': 'var(--bl-color-success-400)',
+        '-500': 'var(--bl-color-success-500)',
+        '-600': 'var(--bl-color-success-600)',
+        '-700': 'var(--bl-color-success-700)',
+        '-800': 'var(--bl-color-success-800)',
+        '-900': 'var(--bl-color-success-900)',
+        '-950': 'var(--bl-color-success-950)',
+    }}
   />
   <ColorItem
     title="--bl-color-danger"
-    subtitle="Danger Color"
-    colors={{ '': 'var(--bl-color-danger)', '--highlight': 'var(--bl-color-danger-highlight)', '--contrast': 'var(--bl-color-danger-contrast)' }}
+    subtitle="Danger Scale"
+    colors={{
+        '-50': 'var(--bl-color-danger-50)',
+        '-100': 'var(--bl-color-danger-100)',
+        '-200': 'var(--bl-color-danger-200)',
+        '-300': 'var(--bl-color-danger-300)',
+        '-400': 'var(--bl-color-danger-400)',
+        '-500': 'var(--bl-color-danger-500)',
+        '-600': 'var(--bl-color-danger-600)',
+        '-700': 'var(--bl-color-danger-700)',
+        '-800': 'var(--bl-color-danger-800)',
+        '-900': 'var(--bl-color-danger-900)',
+        '-950': 'var(--bl-color-danger-950)',
+    }}
   />
   <ColorItem
     title="--bl-color-warning"
-    subtitle="Warning Color"
-    colors={{ '': 'var(--bl-color-warning)', '--highlight': 'var(--bl-color-warning-highlight)', '--contrast': 'var(--bl-color-warning-contrast)' }}
+    subtitle="Warning Scale"
+    colors={{
+        '-50': 'var(--bl-color-warning-50)',
+        '-100': 'var(--bl-color-warning-100)',
+        '-200': 'var(--bl-color-warning-200)',
+        '-300': 'var(--bl-color-warning-300)',
+        '-400': 'var(--bl-color-warning-400)',
+        '-500': 'var(--bl-color-warning-500)',
+        '-600': 'var(--bl-color-warning-600)',
+        '-700': 'var(--bl-color-warning-700)',
+        '-800': 'var(--bl-color-warning-800)',
+        '-900': 'var(--bl-color-warning-900)',
+        '-950': 'var(--bl-color-warning-950)',
+    }}
   />
   <ColorItem
     title="--bl-color-info"
-    subtitle="Info Color"
-    colors={{ '': 'var(--bl-color-info)', '--highlight': 'var(--bl-color-info-highlight)', '--contrast': 'var(--bl-color-info-contrast)' }}
+    subtitle="Info Scale"
+    colors={{
+        '-50': 'var(--bl-color-info-50)',
+        '-100': 'var(--bl-color-info-100)',
+        '-200': 'var(--bl-color-info-200)',
+        '-300': 'var(--bl-color-info-300)',
+        '-400': 'var(--bl-color-info-400)',
+        '-500': 'var(--bl-color-info-500)',
+        '-600': 'var(--bl-color-info-600)',
+        '-700': 'var(--bl-color-info-700)',
+        '-800': 'var(--bl-color-info-800)',
+        '-950': 'var(--bl-color-info-950)',
+    }}
   />
   <ColorItem
-    title="--bl-color-neutral"
-    subtitle="Neutral Colors"
+    title="--bl-color-accent"
+    subtitle="Accent Scale"
     colors={{
-        '--none': 'var(--bl-color-neutral-none)',
-        '--darkest': 'var(--bl-color-neutral-darkest)',
-        '--darker': 'var(--bl-color-neutral-darker)',
-        '--dark': 'var(--bl-color-neutral-dark)',
-        '--light' : 'var(--bl-color-neutral-light)',
-        '--lighter' : 'var(--bl-color-neutral-lighter)',
-        '--lightest' : 'var(--bl-color-neutral-lightest)',
-        '--full' : 'var(--bl-color-neutral-full)',
+        '-50': 'var(--bl-color-accent-50)',
+        '-100': 'var(--bl-color-accent-100)',
+        '-200': 'var(--bl-color-accent-200)',
+        '-300': 'var(--bl-color-accent-300)',
+        '-400': 'var(--bl-color-accent-400)',
+        '-500': 'var(--bl-color-accent-500)',
+        '-600': 'var(--bl-color-accent-600)',
+        '-700': 'var(--bl-color-accent-700)',
+        '-800': 'var(--bl-color-accent-800)',
+        '-900': 'var(--bl-color-accent-900)',
+        '-950': 'var(--bl-color-accent-950)',
+    }}
+  />
+  <ColorItem
+    title="--bl-color-base"
+    subtitle="Base Colors"
+    colors={{ '-white': 'var(--bl-color-base-white)', '-black': 'var(--bl-color-base-black)' }}
+  />
+</ColorPalette>
+
+## Semantic Tokens
+
+Semantic tokens automatically adapt when the theme switches between light and dark (`data-theme="dark"` / `.dark-theme`). Use these in your own components and overrides instead of the primitives above.
+
+<ColorPalette>
+  <ColorItem
+    title="--bl-color-text"
+    subtitle="Text tokens"
+    colors={{
+        '-primary': 'var(--bl-color-text-primary)',
+        '-primary-hover': 'var(--bl-color-text-primary-hover)',
+        '-secondary': 'var(--bl-color-text-secondary)',
+        '-placeholder': 'var(--bl-color-text-placeholder)',
+        '-disabled': 'var(--bl-color-text-disabled)',
+        '-brand': 'var(--bl-color-text-brand)',
+        '-brand-hover': 'var(--bl-color-text-brand-hover)',
+        '-info': 'var(--bl-color-text-info)',
+        '-success': 'var(--bl-color-text-success)',
+        '-warning': 'var(--bl-color-text-warning)',
+        '-danger': 'var(--bl-color-text-danger)',
+        '-accent': 'var(--bl-color-text-accent)',
+    }}
+  />
+  <ColorItem
+    title="--bl-color-border"
+    subtitle="Border tokens"
+    colors={{
+        '-primary': 'var(--bl-color-border-primary)',
+        '-primary-hover': 'var(--bl-color-border-primary-hover)',
+        '-divider': 'var(--bl-color-border-divider)',
+        '-disabled': 'var(--bl-color-border-disabled)',
+        '-tertiary': 'var(--bl-color-border-tertiary)',
+        '-brand': 'var(--bl-color-border-brand)',
+        '-info': 'var(--bl-color-border-info)',
+        '-success': 'var(--bl-color-border-success)',
+        '-warning': 'var(--bl-color-border-warning)',
+        '-danger': 'var(--bl-color-border-danger)',
+        '-neutral': 'var(--bl-color-border-neutral)',
+        '-accent': 'var(--bl-color-border-accent)',
+    }}
+  />
+  <ColorItem
+    title="--bl-color-foreground"
+    subtitle="Foreground tokens (icons, solid fills)"
+    colors={{
+        '-primary': 'var(--bl-color-foreground-primary)',
+        '-primary-hover': 'var(--bl-color-foreground-primary-hover)',
+        '-secondary': 'var(--bl-color-foreground-secondary)',
+        '-placeholder': 'var(--bl-color-foreground-placeholder)',
+        '-disabled': 'var(--bl-color-foreground-disabled)',
+        '-tertiary': 'var(--bl-color-foreground-tertiary)',
+        '-brand': 'var(--bl-color-foreground-brand)',
+        '-brand-hover': 'var(--bl-color-foreground-brand-hover)',
+        '-info': 'var(--bl-color-foreground-info)',
+        '-success': 'var(--bl-color-foreground-success)',
+        '-warning': 'var(--bl-color-foreground-warning)',
+        '-danger': 'var(--bl-color-foreground-danger)',
+        '-featured': 'var(--bl-color-foreground-featured)',
+    }}
+  />
+  <ColorItem
+    title="--bl-color-background"
+    subtitle="Background tokens"
+    colors={{
+        '-primary': 'var(--bl-color-background-primary)',
+        '-primary-hover': 'var(--bl-color-background-primary-hover)',
+        '-secondary': 'var(--bl-color-background-secondary)',
+        '-tertiary': 'var(--bl-color-background-tertiary)',
+        '-disabled': 'var(--bl-color-background-disabled)',
+        '-brand': 'var(--bl-color-background-brand)',
+        '-info': 'var(--bl-color-background-info)',
+        '-success': 'var(--bl-color-background-success)',
+        '-warning': 'var(--bl-color-background-warning)',
+        '-danger': 'var(--bl-color-background-danger)',
+        '-accent': 'var(--bl-color-background-accent)',
     }}
   />
 </ColorPalette>

--- a/docs/how-to-customize-a-components-style.stories.mdx
+++ b/docs/how-to-customize-a-components-style.stories.mdx
@@ -32,8 +32,8 @@ Let's take a badge component as an example:
 
 .badge {
     /* Variable definition start */
-  --bg-color: var(--bl-badge-bg-color, var(--bl-color-primary-contrast));
-  --color: var(--bl-badge-color, var(--bl-color-primary));
+  --bg-color: var(--bl-badge-bg-color, var(--bl-color-background-brand));
+  --color: var(--bl-badge-color, var(--bl-color-text-brand));
   --font: var(--bl-font-title-4-medium);
   --padding-vertical: var(--bl-size-3xs);
   --padding-horizontal: var(--bl-size-3xs);
@@ -59,8 +59,8 @@ By the __nature__ of this component, we let users to change background color and
 we define a default variables `--bl-badge-bg-color` and `--bl-badge-color` and fill it with our default definitions like this:
 
 ```css
---bg-color: var(--bl-badge-bg-color, var(--bl-color-primary-contrast));
---color: var(--bl-badge-color, var(--bl-color-primary));
+--bg-color: var(--bl-badge-bg-color, var(--bl-color-background-brand));
+--color: var(--bl-badge-color, var(--bl-color-text-brand));
 ```
 
 Therefore, if users want to change its background color and/or color, they should change `--bl-badge-bg-color` and/or `--bl-badge-color`.

--- a/docs/using-baklava-in-react.stories.mdx
+++ b/docs/using-baklava-in-react.stories.mdx
@@ -119,8 +119,8 @@ import { BlButton } from "@trendyol/baklava/dist/baklava-react";
 
 function MyComponent() {
   const buttonStyle = {
-    "--bl-color-primary": "purple",
-    "--bl-color-primary-highlight": "rebeccapurple",
+    "--bl-color-foreground-brand": "purple",
+    "--bl-color-foreground-brand-hover": "rebeccapurple",
   }
 
   return (
@@ -139,7 +139,7 @@ import styled from "styled-components"
 
 const Wrapper = styled.div`
    .button-class {
-     --bl-color-primary: purple;
+     --bl-color-foreground-brand: purple;
    }
 
    .tooltip-class {

--- a/src/components/accordion-group/accordion/bl-accordion.css
+++ b/src/components/accordion-group/accordion/bl-accordion.css
@@ -3,7 +3,7 @@
 }
 
 .accordion {
-  --border: 1px solid var(--bl-color-neutral-lighter);
+  --border: 1px solid var(--bl-color-border-primary);
   --default-radius: var(--bl-size-2xs);
   --radius-top-left: var(--bl-accordion-radius-top-left, var(--default-radius));
   --radius-top-right: var(--bl-accordion-radius-top-right, var(--default-radius));
@@ -23,8 +23,8 @@
   justify-content: space-between;
   gap: var(--bl-size-2xs);
   padding: var(--bl-size-m);
-  background: var(--bl-color-neutral-full);
-  color: var(--bl-color-neutral-darker);
+  background: var(--bl-color-background-primary);
+  color: var(--bl-color-text-primary);
   border: var(--border);
   border-bottom: var(--bl-accordion-border-bottom, var(--border));
   border-radius: var(--radius-top-left) var(--radius-top-right) var(--radius-bottom-right)
@@ -37,11 +37,11 @@
 }
 
 .summary:hover {
-  background: var(--bl-color-neutral-lightest);
+  background: var(--bl-color-background-tertiary);
 }
 
 .summary:focus-visible {
-  outline: 2px solid var(--bl-color-primary);
+  outline: 2px solid var(--bl-color-border-brand);
   outline-offset: -1px;
 }
 
@@ -65,7 +65,7 @@
 
 .accordion-content {
   padding: var(--bl-size-m);
-  background: var(--bl-color-neutral-full);
+  background: var(--bl-color-background-primary);
   border: var(--border);
   border-top: 0;
   border-bottom: var(--bl-accordion-border-bottom, var(--border));
@@ -76,8 +76,8 @@
 
 .disabled .summary {
   cursor: not-allowed;
-  background: var(--bl-color-neutral-lightest);
-  color: var(--bl-color-neutral-light);
+  background: var(--bl-color-background-disabled);
+  color: var(--bl-color-text-disabled);
 }
 
 .accordion:not([open]) .accordion-content {

--- a/src/components/alert/bl-alert.css
+++ b/src/components/alert/bl-alert.css
@@ -4,15 +4,15 @@
 
 .alert {
   --padding: var(--bl-size-m);
-  --main-color: var(--bl-color-info);
-  --main-bg-color: var(--bl-color-info-contrast);
+  --main-color: var(--bl-color-foreground-info);
+  --main-bg-color: var(--bl-color-background-info);
 
   position: relative;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   background-color: var(--main-bg-color);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   box-shadow: inset 0 0 0 1px var(--main-color);
   border-radius: var(--bl-border-radius-l);
   padding: calc(var(--padding) / 2) var(--padding);
@@ -50,7 +50,7 @@
 }
 
 .caption {
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   font: var(--bl-font-title-3-medium);
 }
 
@@ -62,7 +62,7 @@
 }
 
 .close {
-  --bl-color-neutral-lightest: transparent;
+  --bl-color-background-tertiary: transparent;
 }
 
 .caption + .description {
@@ -74,16 +74,16 @@
 }
 
 :host([variant="success"]) .alert {
-  --main-color: var(--bl-color-success);
-  --main-bg-color: var(--bl-color-success-contrast);
+  --main-color: var(--bl-color-foreground-success);
+  --main-bg-color: var(--bl-color-background-success);
 }
 
 :host([variant="warning"]) .alert {
-  --main-color: var(--bl-color-warning);
-  --main-bg-color: var(--bl-color-warning-contrast);
+  --main-color: var(--bl-color-foreground-warning);
+  --main-bg-color: var(--bl-color-background-warning);
 }
 
 :host([variant="danger"]) .alert {
-  --main-color: var(--bl-color-danger);
-  --main-bg-color: var(--bl-color-danger-contrast);
+  --main-color: var(--bl-color-foreground-danger);
+  --main-bg-color: var(--bl-color-background-danger);
 }

--- a/src/components/badge/bl-badge.css
+++ b/src/components/badge/bl-badge.css
@@ -4,8 +4,8 @@
 }
 
 .badge {
-  --bg-color: var(--bl-badge-bg-color, var(--bl-color-primary-contrast));
-  --color: var(--bl-badge-color, var(--bl-color-primary));
+  --bg-color: var(--bl-badge-bg-color, var(--bl-color-background-brand));
+  --color: var(--bl-badge-color, var(--bl-color-text-brand));
   --font: var(--bl-font-title-4-medium);
   --padding-vertical: var(--bl-size-4xs);
   --padding-horizontal: var(--bl-size-3xs);

--- a/src/components/badge/bl-badge.stories.mdx
+++ b/src/components/badge/bl-badge.stories.mdx
@@ -45,10 +45,10 @@ export const VariantTemplate = (args) => {
 
   return html`
 ${BadgeTemplate({ content:'In Progress', styles: orangeExampleColors, ...args})}
-${BadgeTemplate({ content:'Approved', styles: { '--bl-badge-bg-color' : 'var(--bl-color-success-contrast)', '--bl-badge-color': 'var(--bl-color-success)' },...args})}
-${BadgeTemplate({ content:'Warning', styles: { '--bl-badge-bg-color' : 'var(--bl-color-warning-contrast)', '--bl-badge-color': 'var(--bl-color-warning)' },...args})}
-${BadgeTemplate({ content:'Denied', styles: { '--bl-badge-bg-color' : 'var(--bl-color-danger-contrast)', '--bl-badge-color': 'var(--bl-color-danger)' },...args})}
-${BadgeTemplate({ content:'Neutral', styles: { '--bl-badge-bg-color' : 'var(--bl-color-neutral-lightest)', '--bl-badge-color': 'var(--bl-color-neutral-darker)' },...args})}
+${BadgeTemplate({ content:'Approved', styles: { '--bl-badge-bg-color' : 'var(--bl-color-background-success)', '--bl-badge-color': 'var(--bl-color-text-success)' },...args})}
+${BadgeTemplate({ content:'Warning', styles: { '--bl-badge-bg-color' : 'var(--bl-color-background-warning)', '--bl-badge-color': 'var(--bl-color-text-warning)' },...args})}
+${BadgeTemplate({ content:'Denied', styles: { '--bl-badge-bg-color' : 'var(--bl-color-background-danger)', '--bl-badge-color': 'var(--bl-color-text-danger)' },...args})}
+${BadgeTemplate({ content:'Neutral', styles: { '--bl-badge-bg-color' : 'var(--bl-color-background-tertiary)', '--bl-badge-color': 'var(--bl-color-text-primary)' },...args})}
 ${BadgeTemplate({ content:'Offer', styles: blueExampleColors, ...args})}
 ${BadgeTemplate({ content:'Winner', styles: purpleExampleColors, ...args})}
 `};
@@ -67,11 +67,11 @@ export const WithIconTemplate = (args) => {
   }
 
   return html`
-${BadgeTemplate({ content:'In Progress', icon: 'clock', styles: { '--bl-badge-bg-color' : 'var(--bl-color-primary-contrast)', '--bl-badge-color': 'var(--bl-color-primary)' },...args})}
-${BadgeTemplate({ content:'Approved', icon: 'check_fill', styles: { '--bl-badge-bg-color' : 'var(--bl-color-success-contrast)', '--bl-badge-color': 'var(--bl-color-success)' },...args})}
-${BadgeTemplate({ content:'Warning', icon: 'warning', styles: { '--bl-badge-bg-color' : 'var(--bl-color-warning-contrast)', '--bl-badge-color': 'var(--bl-color-warning)' },...args})}
-${BadgeTemplate({ content:'Denied', icon: 'close_fill', styles: { '--bl-badge-bg-color' : 'var(--bl-color-danger-contrast)', '--bl-badge-color': 'var(--bl-color-danger)' },...args})}
-${BadgeTemplate({ content:'Neutral', icon: 'alert', styles: { '--bl-badge-bg-color' : 'var(--bl-color-neutral-lightest)', '--bl-badge-color': 'var(--bl-color-neutral-darker)' },...args})}
+${BadgeTemplate({ content:'In Progress', icon: 'clock', styles: { '--bl-badge-bg-color' : 'var(--bl-color-background-brand)', '--bl-badge-color': 'var(--bl-color-text-brand)' },...args})}
+${BadgeTemplate({ content:'Approved', icon: 'check_fill', styles: { '--bl-badge-bg-color' : 'var(--bl-color-background-success)', '--bl-badge-color': 'var(--bl-color-text-success)' },...args})}
+${BadgeTemplate({ content:'Warning', icon: 'warning', styles: { '--bl-badge-bg-color' : 'var(--bl-color-background-warning)', '--bl-badge-color': 'var(--bl-color-text-warning)' },...args})}
+${BadgeTemplate({ content:'Denied', icon: 'close_fill', styles: { '--bl-badge-bg-color' : 'var(--bl-color-background-danger)', '--bl-badge-color': 'var(--bl-color-text-danger)' },...args})}
+${BadgeTemplate({ content:'Neutral', icon: 'alert', styles: { '--bl-badge-bg-color' : 'var(--bl-color-background-tertiary)', '--bl-badge-color': 'var(--bl-color-text-primary)' },...args})}
 ${BadgeTemplate({ content:'Offer', icon: 'offers', styles: blueExampleColors, ...args})}
 ${BadgeTemplate({ content:'Winner', icon: 'award', styles: purpleExampleColors, ...args})}
 `};
@@ -111,7 +111,7 @@ You can use the color model like this ways;
 * `hex`
 * `variables`
 
-Default background color is `--bl-color-primary-contrast` and default color is `--bl-color-primary`.
+Default background color is `--bl-color-background-brand` and default color is `--bl-color-text-brand`.
 
 <Canvas>
 <Story name="Variants">

--- a/src/components/badge/bl-badge.ts
+++ b/src/components/badge/bl-badge.ts
@@ -10,8 +10,8 @@ export type BadgeSize = "small" | "medium" | "large";
  * @tag bl-badge
  * @summary Baklava Badge component
  *
- * @cssproperty [--bl-badge-bg-color=--bl-color-primary-contrast] Sets the background color of badge
- * @cssproperty [--bl-badge-color=--bl-color-primary] Sets the color of badge
+ * @cssproperty [--bl-badge-bg-color=--bl-color-background-brand] Sets the background color of badge
+ * @cssproperty [--bl-badge-color=--bl-color-text-brand] Sets the color of badge
  */
 
 @customElement("bl-badge")

--- a/src/components/badge/doc/ADR.md
+++ b/src/components/badge/doc/ADR.md
@@ -17,13 +17,13 @@ General usage example:
 
 ### Usage Examples
 
-Default background color is `--bl-color-accent-primary-background` and default color is `--bl-color-primary`. But any color can be set like this:
+Default background color is `--bl-color-background-brand` and default color is `--bl-color-text-brand`. But any color can be set like this:
 
 ```html
 <style>
 .danger-badge {
---bl-badge-bg-color:var(--bl-color-danger-background);
---bl-badge-color:var(--bl-color-danger);
+--bl-badge-bg-color:var(--bl-color-background-danger);
+--bl-badge-color:var(--bl-color-text-danger);
 }
 </style>
 

--- a/src/components/button/bl-button.css
+++ b/src/components/button/bl-button.css
@@ -5,10 +5,10 @@
 }
 
 .button {
-  --main-color: var(--bl-color-primary);
-  --main-hover-color: var(--bl-color-primary-highlight);
-  --text-hover-color: var(--bl-color-neutral-lightest);
-  --content-color: var(--bl-color-neutral-full);
+  --main-color: var(--bl-color-foreground-brand);
+  --main-hover-color: var(--bl-color-foreground-brand-hover);
+  --text-hover-color: var(--bl-color-background-tertiary);
+  --content-color: var(--bl-color-foreground-primary-on-color);
   --bg-color: var(--main-color);
   --border-color: var(--main-color);
   --padding-vertical: var(--bl-size-2xs);
@@ -109,18 +109,18 @@
 }
 
 :host([kind="neutral"]) .button {
-  --main-color: var(--bl-color-neutral-darker);
-  --main-hover-color: var(--bl-color-neutral-darkest);
+  --main-color: var(--bl-color-foreground-primary);
+  --main-hover-color: var(--bl-color-foreground-primary-hover);
 }
 
 :host([kind="success"]) .button {
-  --main-color: var(--bl-color-success);
-  --main-hover-color: var(--bl-color-success-highlight);
+  --main-color: var(--bl-color-foreground-success);
+  --main-hover-color: var(--bl-color-foreground-success-hover);
 }
 
 :host([kind="danger"]) .button {
-  --main-color: var(--bl-color-danger);
-  --main-hover-color: var(--bl-color-danger-highlight);
+  --main-color: var(--bl-color-foreground-danger);
+  --main-hover-color: var(--bl-color-foreground-danger-hover);
 }
 
 :host([disabled]) {
@@ -132,9 +132,9 @@
 }
 
 :host .button[aria-disabled="true"] {
-  --main-color: var(--bl-color-neutral-lightest);
-  --main-hover-color: var(--bl-color-neutral-lightest);
-  --content-color: var(--bl-color-neutral-lighter);
+  --main-color: var(--bl-color-background-disabled);
+  --main-hover-color: var(--bl-color-background-disabled);
+  --content-color: var(--bl-color-foreground-disabled);
   --bg-color: var(--main-color);
 
   pointer-events: none;
@@ -146,7 +146,7 @@
 }
 
 :host([variant="secondary"]:hover) .button[aria-disabled="false"] {
-  --content-color: var(--bl-color-neutral-full);
+  --content-color: var(--bl-color-foreground-primary-on-color);
   --bg-color: var(--main-hover-color);
 }
 
@@ -173,12 +173,12 @@
 }
 
 :host([variant="secondary"]) .active.button {
-  --content-color: var(--bl-color-neutral-full);
+  --content-color: var(--bl-color-foreground-primary-on-color);
   --bg-color: var(--main-hover-color);
 }
 
 :host([variant="tertiary"]) .active.button {
   --content-color: var(--main-color);
-  --bg-color: var(--bl-color-neutral-lightest);
+  --bg-color: var(--bl-color-background-tertiary);
   --border-color: transparent;
 }

--- a/src/components/calendar/bl-calendar.css
+++ b/src/components/calendar/bl-calendar.css
@@ -11,7 +11,7 @@
   gap: var(--bl-size-m);
   border-radius: var(--bl-border-radius-s);
   width: fit-content;
-  background: var(--bl-color-neutral-full);
+  background: var(--bl-color-background-primary);
 }
 
 .calendar-header {
@@ -35,7 +35,7 @@
 }
 
 .header-text-hover {
-  background: var(--bl-color-neutral-lightest);
+  background: var(--bl-color-background-tertiary);
   border-radius: var(--bl-border-radius-s);
 }
 
@@ -70,54 +70,54 @@
 }
 
 .day.today-day {
-  --bl-color-neutral-darker: var(--bl-color-primary);
-  --bl-color-neutral-darkest: var(--bl-color-primary);
+  --bl-color-foreground-primary: var(--bl-color-foreground-brand);
+  --bl-color-foreground-primary-hover: var(--bl-color-foreground-brand);
 }
 
 .day.other-month-day {
-  --bl-color-neutral-darker: var(--bl-color-neutral-dark);
+  --bl-color-foreground-primary: var(--bl-color-foreground-secondary);
 }
 
 .day.other-month-day.selected-day {
-  --bl-color-neutral-darker: var(--bl-color-neutral-full);
+  --bl-color-foreground-primary: var(--bl-color-foreground-primary-on-color);
 }
 
 .day.selected-day {
-  background: var(--bl-color-primary);
+  background: var(--bl-color-foreground-brand);
   border-radius: 50%;
 
-  --bl-button-focus-border-color: var(--bl-color-primary);
-  --bl-color-neutral-darker: var(--bl-color-neutral-full);
+  --bl-button-focus-border-color: var(--bl-color-border-brand);
+  --bl-color-foreground-primary: var(--bl-color-foreground-primary-on-color);
 }
 
 .range-day {
-  background: var(--bl-color-primary-contrast);
+  background: var(--bl-color-background-brand);
 
-  --bl-color-neutral-lightest: var(--bl-color-primary-contrast);
+  --bl-color-background-tertiary: var(--bl-color-background-brand);
 }
 
 .range-end-day,
 .range-start-day,
 .selected-day {
-  --bl-color-neutral-lightest: var(--bl-color-primary);
-  --bl-color-neutral-darker: var(--bl-color-neutral-full);
-  --bl-color-neutral-darkest: var(--bl-color-neutral-full) !important;
+  --bl-color-background-tertiary: var(--bl-color-foreground-brand);
+  --bl-color-foreground-primary: var(--bl-color-foreground-primary-on-color);
+  --bl-color-foreground-primary-hover: var(--bl-color-foreground-primary-on-color) !important;
 }
 
 .range-start-day {
-  background: var(--bl-color-primary-contrast);
+  background: var(--bl-color-background-brand);
   border-start-start-radius: 50%;
   border-end-start-radius: 50%;
 }
 
 .range-end-day {
-  background: var(--bl-color-primary-contrast);
+  background: var(--bl-color-background-brand);
   border-start-end-radius: 50%;
   border-end-end-radius: 50%;
 }
 
 .weekday-text {
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
   text-align: center;
   padding: var(--bl-size-2xs) 0;
   width: 40px;

--- a/src/components/checkbox-group/bl-checkbox-group.css
+++ b/src/components/checkbox-group/bl-checkbox-group.css
@@ -10,7 +10,7 @@ fieldset {
 
 legend {
   font: var(--bl-font-title-3-medium);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
 }
 
 .options {
@@ -36,7 +36,7 @@ legend {
 
 .invalid-text {
   display: none;
-  color: var(--bl-color-danger);
+  color: var(--bl-color-text-danger);
 }
 
 .dirty.invalid .hint {

--- a/src/components/checkbox-group/checkbox/bl-checkbox.css
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.css
@@ -10,7 +10,7 @@
 label {
   display: flex;
   gap: var(--bl-size-2xs);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   font: var(--bl-font-title-3);
   cursor: pointer;
   user-select: none;
@@ -33,7 +33,7 @@ input[type="checkbox"] {
   outline: none;
   margin: 0;
   box-sizing: border-box;
-  border: 1px solid var(--bl-color-neutral-lighter);
+  border: 1px solid var(--bl-color-border-primary);
   border-radius: var(--bl-border-radius-xs);
   width: var(--bl-size-m);
   height: var(--bl-size-m);
@@ -55,20 +55,20 @@ input[type="checkbox"] {
   min-height: var(--bl-size-m);
   max-width: var(--bl-size-m);
   max-height: var(--bl-size-m);
-  border: 1px solid var(--bl-color-neutral-lighter);
+  border: 1px solid var(--bl-color-border-primary);
   border-radius: var(--bl-border-radius-xs);
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
   font-size: var(--bl-font-size-2xs);
-  background-color: var(--bl-color-neutral-full);
+  background-color: var(--bl-color-background-primary);
 }
 
 .required-suffix {
-  color: var(--bl-color-danger);
+  color: var(--bl-color-text-danger);
   margin-inline-start: calc(var(--bl-size-2xs) * -1);
 }
 
 .dirty.invalid .check-mark {
-  border-color: var(--bl-color-danger);
+  border-color: var(--bl-color-border-danger);
 }
 
 .hint {
@@ -87,7 +87,7 @@ input[type="checkbox"] {
 
 .invalid-text {
   display: none;
-  color: var(--bl-color-danger);
+  color: var(--bl-color-text-danger);
 }
 
 .dirty.invalid .invalid-text {
@@ -96,11 +96,11 @@ input[type="checkbox"] {
 
 :host([checked]) .label,
 :host(:hover) .label {
-  color: var(--bl-color-primary);
+  color: var(--bl-color-text-brand);
 }
 
 :host(:is([checked], [indeterminate])) .check-mark {
-  background-color: var(--bl-color-primary);
+  background-color: var(--bl-color-foreground-brand);
   border: none;
 }
 
@@ -111,14 +111,14 @@ input[type="checkbox"] {
 
 :host([disabled]) .check-mark,
 :host([disabled]) .label {
-  color: var(--bl-color-neutral-light);
-  border: 1px solid var(--bl-color-neutral-lighter);
+  color: var(--bl-color-text-disabled);
+  border: 1px solid var(--bl-color-border-disabled);
 }
 
 :host([disabled]) .check-mark {
-  background-color: var(--bl-color-neutral-lightest);
+  background-color: var(--bl-color-background-disabled);
 }
 
 :host(:not([disabled])) input:focus-visible + .check-mark {
-  box-shadow: 0 0 0 1px white, 0 0 0 3px var(--bl-color-primary);
+  box-shadow: 0 0 0 1px white, 0 0 0 3px var(--bl-color-border-brand);
 }

--- a/src/components/checkbox-group/checkbox/bl-checkbox.stories.mdx
+++ b/src/components/checkbox-group/checkbox/bl-checkbox.stories.mdx
@@ -39,7 +39,7 @@ export const CheckboxLimitedWidthTemplate = (args) => html`<div style="max-width
   ${CheckboxTemplate(args)}
 </div>`;
 
-export const CheckboxDifferentBackgroundTemplate = (args) => html`<div style="padding: 20px; background-color: var(--bl-color-primary-contrast);">
+export const CheckboxDifferentBackgroundTemplate = (args) => html`<div style="padding: 20px; background-color: var(--bl-color-background-brand);">
   ${CheckboxTemplate(args)}
 </div>`;
 

--- a/src/components/checkbox-group/doc/ADR.md
+++ b/src/components/checkbox-group/doc/ADR.md
@@ -17,7 +17,8 @@ General usage example:
 ```html
 <style>
 .checkbox-new {
-   --bl-color-primary: rebeccapurple;
+   --bl-color-foreground-brand: rebeccapurple;
+   --bl-color-text-brand: rebeccapurple;
 }
 </style>
 

--- a/src/components/datepicker/bl-datepicker.css
+++ b/src/components/datepicker/bl-datepicker.css
@@ -6,7 +6,7 @@
 .datepicker-content {
   --bl-input-cursor: pointer;
   --icon-size: var(--line-height);
-  --icon-color: var(--bl-color-neutral-light);
+  --icon-color: var(--bl-color-foreground-placeholder);
 
   width: 100%;
   position: relative;
@@ -45,7 +45,7 @@
   display: block;
   height: var(--bl-size-m);
   width: 1px;
-  background-color: var(--bl-color-neutral-lighter);
+  background-color: var(--bl-color-border-primary);
   margin-right: var(--bl-size-3xs);
 }
 

--- a/src/components/dialog/bl-dialog.css
+++ b/src/components/dialog/bl-dialog.css
@@ -3,7 +3,7 @@
 }
 
 .container {
-  --background-color: var(--bl-color-neutral-full);
+  --background-color: var(--bl-color-background-primary);
 
   display: flex;
   flex-direction: column;
@@ -30,7 +30,7 @@
 }
 
 .dialog::backdrop {
-  background-color: #273142b3;
+  background-color: #292e32b3;
 }
 
 .dialog-polyfill {
@@ -43,7 +43,7 @@
   align-items: center;
   justify-content: center;
   z-index: var(--bl-index-dialog);
-  background-color: #273142b3;
+  background-color: #292e32b3;
 }
 
 :host([open]) .dialog-polyfill {
@@ -64,7 +64,7 @@ header bl-button {
 
 header h2 {
   font: var(--bl-font-title-1-medium);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   overflow: hidden;
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -99,7 +99,7 @@ footer {
 
 footer.shadow {
   /* FIXME: Use variables for sizes */
-  box-shadow: 0 -4px 15px #27314226;
+  box-shadow: 0 -4px 15px #292e3226;
 }
 
 @media only screen and (max-width: 471px) {

--- a/src/components/drawer/bl-drawer.css
+++ b/src/components/drawer/bl-drawer.css
@@ -10,7 +10,7 @@
   padding-top: max(env(safe-area-inset-top), var(--bl-size-xl));
   padding-inline-end: max(env(safe-area-inset-right), var(--bl-size-xl));
   padding-bottom: max(env(safe-area-inset-bottom), var(--bl-size-xl));
-  background: var(--bl-color-neutral-full);
+  background: var(--bl-color-background-primary);
   box-shadow: var(--bl-size-xs) 0 var(--bl-size-2xl) rgba(0 0 0 / 50%);
   transition: right var(--bl-drawer-animation-duration, 0.25s);
   z-index: var(--bl-index-sticky);
@@ -45,7 +45,7 @@ header .header-buttons {
 
 header h2 {
   font: var(--bl-font-title-1-medium);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   overflow: hidden;
   margin: 0;
   padding: 0;

--- a/src/components/dropdown/bl-dropdown.css
+++ b/src/components/dropdown/bl-dropdown.css
@@ -4,15 +4,15 @@
 }
 
 :host([kind="neutral"]) bl-popover {
-  --bl-popover-border-color: var(--bl-color-neutral-darker);
+  --bl-popover-border-color: var(--bl-color-border-neutral);
 }
 
 :host([kind="success"]) bl-popover {
-  --bl-popover-border-color: var(--bl-color-success);
+  --bl-popover-border-color: var(--bl-color-border-success);
 }
 
 :host([kind="danger"]) bl-popover {
-  --bl-popover-border-color: var(--bl-color-danger);
+  --bl-popover-border-color: var(--bl-color-border-danger);
 }
 
 .popover-content {

--- a/src/components/dropdown/docs/ADR/group-support.md
+++ b/src/components/dropdown/docs/ADR/group-support.md
@@ -40,12 +40,12 @@ export default class BlDropdownGroup extends LitElement {
 
 // Visual separation between groups
 :host(:not(:first-child)) .dropdown-group {
-  border-top: 1px solid var(--bl-color-neutral-lighter);
+  border-top: 1px solid var(--bl-color-border-primary);
   padding-top: var(--bl-size-xs);
 }
 
 :host(:not(:last-child)) .dropdown-group {
-  border-bottom: 1px solid var(--bl-color-neutral-lighter);
+  border-bottom: 1px solid var(--bl-color-border-primary);
   padding-bottom: var(--bl-size-xs);
 }
 ```

--- a/src/components/dropdown/docs/ADR/variant-system.md
+++ b/src/components/dropdown/docs/ADR/variant-system.md
@@ -38,15 +38,15 @@ export default class BlDropdown extends LitElement {
 ## CSS Implementation
 ```css
 :host([kind="neutral"]) bl-popover {
-  --bl-popover-border-color: var(--bl-color-neutral-darker);
+  --bl-popover-border-color: var(--bl-color-border-neutral);
 }
 
 :host([kind="success"]) bl-popover {
-  --bl-popover-border-color: var(--bl-color-success);
+  --bl-popover-border-color: var(--bl-color-border-success);
 }
 
 :host([kind="danger"]) bl-popover {
-  --bl-popover-border-color: var(--bl-color-danger);
+  --bl-popover-border-color: var(--bl-color-border-danger);
 }
 ```
 

--- a/src/components/dropdown/group/bl-dropdown-group.css
+++ b/src/components/dropdown/group/bl-dropdown-group.css
@@ -15,17 +15,17 @@
   font-size: var(--bl-font-size-xs);
   font-weight: var(--bl-font-weight-medium);
   line-height: var(--bl-font-size-s);
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
 }
 
 :host(:not(:first-child)) .dropdown-group {
-  border-top: 1px solid var(--bl-color-neutral-lighter);
+  border-top: 1px solid var(--bl-color-border-primary);
   padding-top: var(--bl-size-xs);
 }
 
 /*
 :host(:not(:last-child)) .dropdown-group {
-  border-bottom: 1px solid var(--bl-color-neutral-lighter);
+  border-bottom: 1px solid var(--bl-color-border-primary);
   padding-bottom: var(--bl-size-xs);
 }
 */

--- a/src/components/icon/bl-icon.stories.mdx
+++ b/src/components/icon/bl-icon.stories.mdx
@@ -29,13 +29,13 @@ import icons from './icon-list';
         type: 'color',
         description: 'Color of the icon',
         presetColors: [{
-          color: 'var(--bl-color-primary)',
+          color: 'var(--bl-color-foreground-brand)',
           title: 'Primary'
         },{
-          color: 'var(--bl-color-success)',
+          color: 'var(--bl-color-foreground-success)',
           title: 'Success'
         },{
-          color: 'var(--bl-color-danger)',
+          color: 'var(--bl-color-foreground-danger)',
           title: 'Danger'
         }]
       }
@@ -56,10 +56,10 @@ export const SizeVariations = (args) => html`
 `
 
 export const ColorVariations = (args) => html`
-<bl-icon name="${args.name}" style="color: var(--bl-color-neutral-darker)"></bl-icon>
-<bl-icon name="${args.name}" style="color: var(--bl-color-neutral-dark)"></bl-icon>
-<bl-icon name="${args.name}" style="color: var(--bl-color-neutral-light)"></bl-icon>
-<bl-icon name="${args.name}" style="color: var(--bl-color-neutral-lighter)"></bl-icon>
+<bl-icon name="${args.name}" style="color: var(--bl-color-foreground-primary)"></bl-icon>
+<bl-icon name="${args.name}" style="color: var(--bl-color-foreground-secondary)"></bl-icon>
+<bl-icon name="${args.name}" style="color: var(--bl-color-foreground-placeholder)"></bl-icon>
+<bl-icon name="${args.name}" style="color: var(--bl-color-foreground-disabled)"></bl-icon>
 `
 
 export const AllIcons = (args) => html`<div

--- a/src/components/input/bl-input.css
+++ b/src/components/input/bl-input.css
@@ -5,9 +5,9 @@
 }
 
 .wrapper {
-  --border-color: var(--bl-color-neutral-lighter);
-  --icon-color: var(--bl-color-neutral-light);
-  --text-color: var(--bl-color-neutral-darker);
+  --border-color: var(--bl-color-border-primary);
+  --icon-color: var(--bl-color-foreground-placeholder);
+  --text-color: var(--bl-color-text-primary);
   --height: var(--bl-size-2xl);
   --input-font: var(--bl-font-body-text-2);
   --line-height: var(--bl-font-body-text-2-line-height);
@@ -15,9 +15,9 @@
   --icon-gap: var(--bl-size-4xs);
   --padding-vertical: calc((var(--height) - var(--line-height)) / 2);
   --padding-horizontal: var(--bl-size-xs);
-  --autofill-bg-color: var(--bl-color-primary-contrast);
+  --autofill-bg-color: var(--bl-color-background-brand);
   --label-padding: var(--bl-size-2xs);
-  --background-color: var(--bl-color-neutral-full);
+  --background-color: var(--bl-color-background-primary);
 
   display: grid;
   position: relative;
@@ -25,13 +25,13 @@
 }
 
 .wrapper:focus-within {
-  --border-color: var(--bl-color-primary);
-  --icon-color: var(--bl-color-primary);
+  --border-color: var(--bl-color-border-brand);
+  --icon-color: var(--bl-color-foreground-brand);
 }
 
 .wrapper.dirty.invalid {
-  --border-color: var(--bl-color-danger);
-  --icon-color: var(--bl-color-danger);
+  --border-color: var(--bl-color-border-danger);
+  --icon-color: var(--bl-color-foreground-danger);
 }
 
 :host([size="large"]) .wrapper {
@@ -74,8 +74,8 @@
 :host([disabled]) .wrapper {
   cursor: not-allowed;
 
-  --background-color: var(--bl-color-neutral-lightest);
-  --text-color: var(--bl-color-neutral-light);
+  --background-color: var(--bl-color-background-disabled);
+  --text-color: var(--bl-color-text-disabled);
 }
 
 .wrapper:has(input:autofill) {
@@ -89,7 +89,7 @@
 :host([required-indicator]) label::after,
 :host([required-indicator]) .input-wrapper legend span::after {
   content: "*";
-  color: var(--bl-color-danger);
+  color: var(--bl-color-text-danger);
 }
 
 .input-wrapper legend,
@@ -109,7 +109,7 @@ label {
   inset-inline-start: var(--bl-input-padding-start, var(--padding-horizontal));
   inset-inline-end: var(--bl-input-padding-end, var(--padding-horizontal));
   pointer-events: none;
-  color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-placeholder);
 }
 
 .has-icon label {
@@ -242,8 +242,8 @@ bl-icon[name="eye_on"] {
 }
 
 ::placeholder {
-  color: var(--bl-color-neutral-light);
-  -webkit-text-fill-color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-placeholder);
+  -webkit-text-fill-color: var(--bl-color-text-placeholder);
 }
 
 :host([label]) ::placeholder {
@@ -254,8 +254,8 @@ bl-icon[name="eye_on"] {
 
 :host([label-fixed]) ::placeholder,
 :host :focus-within ::placeholder {
-  color: var(--bl-color-neutral-light);
-  -webkit-text-fill-color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-placeholder);
+  -webkit-text-fill-color: var(--bl-color-text-placeholder);
 }
 
 :host([label-fixed]) label {
@@ -264,7 +264,7 @@ bl-icon[name="eye_on"] {
   transform: none;
   pointer-events: initial;
   font: var(--bl-font-caption);
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
   padding: 0;
 }
 
@@ -283,7 +283,7 @@ bl-icon[name="eye_on"] {
   );
   transform: translateY(-50%);
   font: var(--bl-font-caption);
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
   padding: 0 var(--label-padding);
   pointer-events: initial;
   z-index: var(--bl-index-base);
@@ -303,11 +303,11 @@ bl-icon[name="eye_on"] {
 .dirty.invalid label,
 .invalid-text,
 .error-icon {
-  color: var(--bl-color-danger);
+  color: var(--bl-color-text-danger);
 }
 
 .help-text {
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
 }
 
 :host([help-text]) .hint,
@@ -331,7 +331,7 @@ bl-icon[name="eye_on"] {
   display: block;
   height: 1rem;
   width: 1px;
-  background-color: var(--bl-color-neutral-lighter);
+  background-color: var(--bl-color-border-primary);
 }
 
 slot[name="icon"] bl-icon {

--- a/src/components/link/bl-link.css
+++ b/src/components/link/bl-link.css
@@ -5,9 +5,9 @@
 
 .link {
   /* Custom properties */
-  --color: var(--bl-link-color, var(--bl-color-primary));
-  --hover-color: var(--bl-link-hover-color, var(--bl-color-primary-highlight));
-  --active-color: var(--bl-link-active-color, var(--bl-color-primary-highlight));
+  --color: var(--bl-link-color, var(--bl-color-text-brand));
+  --hover-color: var(--bl-link-hover-color, var(--bl-color-text-brand-hover));
+  --active-color: var(--bl-link-active-color, var(--bl-color-text-brand-hover));
 
   /* Base styles */
   display: inline-flex;
@@ -38,28 +38,28 @@
   content: "";
   position: absolute;
   inset: -2px;
-  border: 2px solid var(--bl-color-primary);
+  border: 2px solid var(--bl-color-border-brand);
   border-radius: var(--bl-border-radius-s);
 }
 
 /* Primary kind */
 .link.standalone.kind-primary {
-  color: var(--bl-color-primary);
+  color: var(--bl-color-text-brand);
 }
 
 .link.standalone.kind-primary:hover,
 .link.standalone.kind-primary:active {
-  color: var(--bl-color-primary-highlight);
+  color: var(--bl-color-text-brand-hover);
 }
 
 /* Neutral kind */
 .link.standalone.kind-neutral {
-  color: var(--bl-color-neutral);
+  color: var(--bl-color-text-primary);
 }
 
 .link.standalone.kind-neutral:hover,
 .link.standalone.kind-neutral:active {
-  color: var(--bl-color-neutral-highlight);
+  color: var(--bl-color-text-primary-hover);
 }
 
 /* Size variants */

--- a/src/components/link/bl-link.stories.ts
+++ b/src/components/link/bl-link.stories.ts
@@ -46,10 +46,10 @@ const meta: Meta<LinkArgs> = {
             "</p>" +
 
             "<div class=\"bl-docs-links\" style=\"display: flex; gap: var(--bl-size-2xs); margin-top: var(--bl-size-m);\">" +
-              "<bl-badge icon=\"document\" style=\"--bl-badge-background: var(--bl-color-surface-hover)\">" +
+              "<bl-badge icon=\"document\" style=\"--bl-badge-background: var(--bl-color-background-tertiary)\">" +
                 "<bl-link variant='inline' href='" + ADR_LINK + "' target='_blank'>ADR</bl-link>" +
               "</bl-badge>" +
-              "<bl-badge icon=\"puzzle\" style=\"--bl-badge-background: var(--bl-color-surface-hover)\">" +
+              "<bl-badge icon=\"puzzle\" style=\"--bl-badge-background: var(--bl-color-background-tertiary)\">" +
                 "<bl-link variant='inline' href='" + FIGMA_LINK + "' target='_blank'>Figma</bl-link>" +
               "</bl-badge>" +
             "</div>" +
@@ -314,17 +314,17 @@ export const CustomInlineColors: Story = {
       ${LinkTemplate({
         href: "/",
         content: "Success Link",
-        customStyles: "--bl-link-color: var(--bl-color-success); --bl-link-hover-color: var(--bl-color-success-highlight); --bl-link-active-color: var(--bl-color-success-highlight);"
+        customStyles: "--bl-link-color: var(--bl-color-text-success); --bl-link-hover-color: var(--bl-color-text-success-hover); --bl-link-active-color: var(--bl-color-text-success-hover);"
       })}
       ${LinkTemplate({
         href: "/",
         content: "Warning Link",
-        customStyles: "--bl-link-color: var(--bl-color-warning); --bl-link-hover-color: var(--bl-color-warning-highlight); --bl-link-active-color: var(--bl-color-warning-highlight);"
+        customStyles: "--bl-link-color: var(--bl-color-text-warning); --bl-link-hover-color: var(--bl-color-text-warning-hover); --bl-link-active-color: var(--bl-color-text-warning-hover);"
       })}
       ${LinkTemplate({
         href: "/",
         content: "Danger Link",
-        customStyles: "--bl-link-color: var(--bl-color-danger); --bl-link-hover-color: var(--bl-color-danger-highlight); --bl-link-active-color: var(--bl-color-danger-highlight);"
+        customStyles: "--bl-link-color: var(--bl-color-text-danger); --bl-link-hover-color: var(--bl-color-text-danger-hover); --bl-link-active-color: var(--bl-color-text-danger-hover);"
       })}
     </div>
   `,

--- a/src/components/link/bl-link.ts
+++ b/src/components/link/bl-link.ts
@@ -14,9 +14,9 @@ export type LinkKind = "primary" | "neutral";
  *
  * @slot icon - Custom icon slot for non-standalone variants
  *
- * @cssproperty [--bl-link-color=--bl-color-primary] Sets the color of link
- * @cssproperty [--bl-link-hover-color=--bl-color-primary-hover] Sets the hover color of link
- * @cssproperty [--bl-link-active-color=--bl-color-primary-active] Sets the active color of link
+ * @cssproperty [--bl-link-color=--bl-color-text-brand] Sets the color of link
+ * @cssproperty [--bl-link-hover-color=--bl-color-text-brand-hover] Sets the hover color of link
+ * @cssproperty [--bl-link-active-color=--bl-color-text-brand-hover] Sets the active color of link
  */
 
 @customElement("bl-link")

--- a/src/components/link/docs/ADR/link-component-implementation.md
+++ b/src/components/link/docs/ADR/link-component-implementation.md
@@ -66,9 +66,9 @@ We will implement a Link component with the following key characteristics:
    - CSS Custom Properties:
      ```css
      :host {
-       --bl-link-color: var(--bl-color-primary);           /* Default link color */
-       --bl-link-hover-color: var(--bl-color-primary-hover);   /* Hover state color */
-       --bl-link-active-color: var(--bl-color-primary-active); /* Active state color */
+       --bl-link-color: var(--bl-color-text-brand);           /* Default link color */
+       --bl-link-hover-color: var(--bl-color-text-brand-hover);   /* Hover state color */
+       --bl-link-active-color: var(--bl-color-text-brand-hover); /* Active state color */
      }
      ```
    - Inline Variant Validation:
@@ -156,9 +156,9 @@ We will implement a Link component with the following key characteristics:
       <bl-link
         href="/success"
         style="
-          --bl-link-color: var(--bl-color-success);
-          --bl-link-hover-color: var(--bl-color-success-hover);
-          --bl-link-active-color: var(--bl-color-success-active);
+          --bl-link-color: var(--bl-color-text-success);
+          --bl-link-hover-color: var(--bl-color-text-success-hover);
+          --bl-link-active-color: var(--bl-color-text-success-hover);
         "
       >
         Success Link

--- a/src/components/notification/card/bl-notification-card.css
+++ b/src/components/notification/card/bl-notification-card.css
@@ -41,17 +41,17 @@
 }
 
 .notification[variant="success"] .duration > .remaining {
-  background-color: var(--bl-color-success);
+  background-color: var(--bl-color-foreground-success);
 }
 
 .notification[variant="warning"] .duration > .remaining {
-  background-color: var(--bl-color-warning);
+  background-color: var(--bl-color-foreground-warning);
 }
 
 .notification[variant="danger"] .duration > .remaining {
-  background-color: var(--bl-color-danger);
+  background-color: var(--bl-color-foreground-danger);
 }
 
 .notification[variant="info"] .duration > .remaining {
-  background-color: var(--bl-color-info);
+  background-color: var(--bl-color-foreground-info);
 }

--- a/src/components/pagination/bl-pagination.css
+++ b/src/components/pagination/bl-pagination.css
@@ -35,7 +35,7 @@
 
 .dots::before {
   content: " \B7 \B7 \B7";
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
 }
 
 .pagination-helpers {
@@ -44,7 +44,7 @@
   justify-content: center;
   align-items: center;
   gap: var(--bl-size-m);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
 }
 
 .jumper,

--- a/src/components/popover/bl-popover.css
+++ b/src/components/popover/bl-popover.css
@@ -4,8 +4,8 @@
 
 .popover {
   --arrow-display: var(--bl-popover-arrow-display, none);
-  --background-color: var(--bl-popover-background-color, var(--bl-color-neutral-full));
-  --border-color: var(--bl-popover-border-color, var(--bl-color-primary-highlight));
+  --background-color: var(--bl-popover-background-color, var(--bl-color-background-primary));
+  --border-color: var(--bl-popover-border-color, var(--bl-color-border-primary-hover));
   --border-size: var(--bl-popover-border-size, 1px);
   --padding: var(--bl-popover-padding, var(--bl-size-m));
   --border-radius: var(--bl-popover-border-radius, var(--bl-size-3xs));
@@ -24,7 +24,7 @@
   hyphens: auto;
   background-color: var(--background-color);
   font: var(--bl-font-title-3-regular);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
 
   /* UA [popover] sets inset:0; margin:auto; overflow:auto — reset so floating-ui's left/top position wins and the arrow isn't clipped */
   margin: 0;

--- a/src/components/popover/bl-popover.stories.mdx
+++ b/src/components/popover/bl-popover.stories.mdx
@@ -184,7 +184,7 @@ By default arrow is not visible. You can use options below:
 
 ## Background Color
 
-You can give `--bl-popover-background-color` for popover background. Default color is `--bl-color-neutral-full`.
+You can give `--bl-popover-background-color` for popover background. Default color is `--bl-color-background-primary`.
 
 <Canvas>
   <Story name="Background Color"
@@ -198,7 +198,7 @@ You can give `--bl-popover-background-color` for popover background. Default col
 
 ## Border Color
 
-You can give `--bl-popover-border-color` for popover border color. Default color is `--bl-color-primary-highlight`.
+You can give `--bl-popover-border-color` for popover border color. Default color is `--bl-color-border-primary-hover`.
 
 <Canvas>
   <Story name="Border Color"

--- a/src/components/popover/bl-popover.ts
+++ b/src/components/popover/bl-popover.ts
@@ -39,8 +39,8 @@ export type Placement =
  * @summary Baklava Popover component
  *
  * @cssproperty [--bl-popover-arrow-display=none] - Sets the display of popovers arrow. Set as `block` to make arrow visible.
- * @cssproperty [--bl-popover-background-color=--bl-color-neutral-full] - Sets the background color of popover.
- * @cssproperty [--bl-popover-border-color=--bl-color-primary-highlight] - Sets the border color of popover.
+ * @cssproperty [--bl-popover-background-color=--bl-color-background-primary] - Sets the background color of popover.
+ * @cssproperty [--bl-popover-border-color=--bl-color-border-primary-hover] - Sets the border color of popover.
  * @cssproperty [--bl-popover-border-size=1px] - Sets the border size of popover. You can set it to `0px` to not have a border (if you use a custom background color). Always use with a length unit.
  * @cssproperty [--bl-popover-padding=--bl-size-m] - Sets the padding of popover.
  * @cssproperty [--bl-popbover-border-radius=--bl-size-3xs] - Sets the border radius of popover.

--- a/src/components/progress-indicator/bl-progress-indicator.css
+++ b/src/components/progress-indicator/bl-progress-indicator.css
@@ -1,12 +1,12 @@
 .progress-indicator {
   --max: 100;
   --value: 0;
-  --value-color: var(--bl-color-success);
+  --value-color: var(--bl-color-foreground-success);
   --height: var(--bl-size-2xs);
   --radius: var(--bl-border-radius-s);
 
   position: relative;
-  background-color: var(--bl-color-neutral-lightest);
+  background-color: var(--bl-color-background-tertiary);
   height: var(--height);
   border-radius: var(--radius);
   width: 100%;
@@ -34,5 +34,5 @@
 }
 
 :host([failed]) .progress-indicator {
-  --value-color: var(--bl-color-danger);
+  --value-color: var(--bl-color-foreground-danger);
 }

--- a/src/components/progress-indicator/bl-progress-indicator.stories.mdx
+++ b/src/components/progress-indicator/bl-progress-indicator.stories.mdx
@@ -38,12 +38,12 @@ export const ProgressIndicatorTemplate = (args) => html`
 
 export const FailedTemplate = (args) => html`
 <div>
-<p style='color: var(--bl-color-danger); margin: var(--bl-size-3xs); font: var(--bl-font-title-4-regular)'>Upload Failed - Image must not be larger than 3mb.</p>${ProgressIndicatorTemplate({ value:'100', failed:true, ...args })}
+<p style='color: var(--bl-color-text-danger); margin: var(--bl-size-3xs); font: var(--bl-font-title-4-regular)'>Upload Failed - Image must not be larger than 3mb.</p>${ProgressIndicatorTemplate({ value:'100', failed:true, ...args })}
 </div>`;
 
 export const WithMaxTemplate = (args) => html`
 <div>
-<p style='color: var(--bl-color-neutral-dark); margin: var(--bl-size-3xs); font: var(--bl-font-title-4-regular)'> Completed Tasks: <b style='color: var(--bl-color-success)'> 5/8 </b></p>${ProgressIndicatorTemplate({ max:'8', value: '5', ...args })}
+<p style='color: var(--bl-color-text-secondary); margin: var(--bl-size-3xs); font: var(--bl-font-title-4-regular)'> Completed Tasks: <b style='color: var(--bl-color-text-success)'> 5/8 </b></p>${ProgressIndicatorTemplate({ max:'8', value: '5', ...args })}
 </div>`;
 
 # Progress Indicator
@@ -113,8 +113,8 @@ The progress indicator component supports RTL (Right-to-Left) text direction. Yo
         <div>
           <p style="margin-bottom: 8px;">LTR (Left-to-Right)</p>
           <div>
-            <p style="color: var(--bl-color-neutral-dark); margin: var(--bl-size-3xs); font: var(--bl-font-title-4-regular)">
-              Completed Tasks: <b style="color: var(--bl-color-success)">5/8</b>
+            <p style="color: var(--bl-color-text-secondary); margin: var(--bl-size-3xs); font: var(--bl-font-title-4-regular)">
+              Completed Tasks: <b style="color: var(--bl-color-text-success)">5/8</b>
             </p>
             <bl-progress-indicator max="8" value="5"></bl-progress-indicator>
           </div>
@@ -122,8 +122,8 @@ The progress indicator component supports RTL (Right-to-Left) text direction. Yo
         <div dir="rtl">
           <p style="margin-bottom: 8px;">RTL (Right-to-Left)</p>
           <div>
-            <p style="color: var(--bl-color-neutral-dark); margin: var(--bl-size-3xs); font: var(--bl-font-title-4-regular)">
-              المهام المكتملة: <b style="color: var(--bl-color-success)">5/8</b>
+            <p style="color: var(--bl-color-text-secondary); margin: var(--bl-size-3xs); font: var(--bl-font-title-4-regular)">
+              المهام المكتملة: <b style="color: var(--bl-color-text-success)">5/8</b>
             </p>
             <bl-progress-indicator max="8" value="5"></bl-progress-indicator>
           </div>
@@ -156,12 +156,12 @@ Here's a vanilla JavaScript and HTML example of how to use RTL support:
       margin-bottom: 16px;
     }
     .progress-text {
-      color: var(--bl-color-neutral-dark);
+      color: var(--bl-color-text-secondary);
       margin: var(--bl-size-3xs);
       font: var(--bl-font-title-4-regular);
     }
     .progress-value {
-      color: var(--bl-color-success);
+      color: var(--bl-color-text-success);
       font-weight: bold;
     }
   </style>

--- a/src/components/radio-group/bl-radio-group.css
+++ b/src/components/radio-group/bl-radio-group.css
@@ -9,7 +9,7 @@ fieldset {
 
 legend {
   font: var(--bl-font-title-3-medium);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
 }
 
 .options {

--- a/src/components/radio-group/radio/bl-radio.css
+++ b/src/components/radio-group/radio/bl-radio.css
@@ -15,7 +15,7 @@
   line-height: normal;
   align-items: var(--bl-radio-align-items, center);
   margin-block: 0;
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   gap: var(--bl-size-2xs);
 }
 
@@ -29,17 +29,17 @@
   max-height: var(--size);
   background-color: white;
   border-radius: var(--bl-border-radius-circle);
-  border: solid 1px var(--bl-color-neutral-lighter);
+  border: solid 1px var(--bl-color-border-primary);
 }
 
 .selected #label::before {
   border-width: var(--bl-size-3xs);
-  border-color: var(--bl-color-primary);
+  border-color: var(--bl-color-border-brand);
 }
 
 :host(:hover) #label,
 .selected #label {
-  color: var(--bl-color-primary);
+  color: var(--bl-color-text-brand);
 }
 
 :host([disabled]) {
@@ -52,21 +52,21 @@
 }
 
 :host([disabled]) #label {
-  color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-disabled);
 }
 
 :host([disabled]) #label::before {
-  background-color: var(--bl-color-neutral-lightest);
+  background-color: var(--bl-color-background-disabled);
   border-width: 0;
-  box-shadow: 0 0 0 1px var(--bl-color-neutral-lighter);
+  box-shadow: 0 0 0 1px var(--bl-color-border-disabled);
 }
 
 :host([disabled]) .selected #label::before {
-  background-color: var(--bl-color-neutral-light);
-  border-color: var(--bl-color-neutral-lightest);
+  background-color: var(--bl-color-foreground-disabled);
+  border-color: var(--bl-color-background-disabled);
   border-width: calc(var(--bl-size-3xs) - 1px);
 }
 
 .wrapper:focus-visible #label::before {
-  box-shadow: 0 0 0 1px white, 0 0 0 3px var(--bl-color-primary);
+  box-shadow: 0 0 0 1px white, 0 0 0 3px var(--bl-color-border-brand);
 }

--- a/src/components/select/bl-select.css
+++ b/src/components/select/bl-select.css
@@ -13,18 +13,18 @@
   --padding-horizontal: var(--bl-size-xs);
   --label-padding: var(--bl-size-3xs);
   --border-size: 1px;
-  --background-color: var(--bl-color-neutral-full);
-  --border-color: var(--bl-color-neutral-lighter);
-  --border-focus-color: var(--bl-color-primary-highlight);
-  --icon-color: var(--bl-color-neutral-light);
-  --text-color: var(--bl-color-neutral-darker);
-  --label-color: var(--bl-color-neutral-dark);
-  --placeholder-color: var(--bl-color-neutral-light);
+  --background-color: var(--bl-color-background-primary);
+  --border-color: var(--bl-color-border-primary);
+  --border-focus-color: var(--bl-color-border-primary-hover);
+  --icon-color: var(--bl-color-foreground-placeholder);
+  --text-color: var(--bl-color-text-primary);
+  --label-color: var(--bl-color-text-secondary);
+  --placeholder-color: var(--bl-color-text-placeholder);
   --height: var(--bl-size-2xl);
   --menu-padding: 0 var(--bl-size-m);
   --menu-margin-top: var(--bl-size-2xs);
   --font-size: var(--bl-font-size-m);
-  --disabled-color: var(--bl-color-neutral-lightest);
+  --disabled-color: var(--bl-color-background-disabled);
   --menu-height: 250px;
   --popover-position: var(--bl-popover-position, fixed);
 }
@@ -47,13 +47,13 @@
 }
 
 :host([disabled]) .select-wrapper {
-  --placeholder-color: var(--bl-color-neutral-light);
+  --placeholder-color: var(--bl-color-text-disabled);
 }
 
 .dirty.invalid {
-  --border-color: var(--bl-color-danger);
-  --border-focus-color: var(--bl-color-danger-highlight);
-  --label-color: var(--bl-color-danger);
+  --border-color: var(--bl-color-border-danger);
+  --border-focus-color: var(--bl-color-border-danger);
+  --label-color: var(--bl-color-text-danger);
 }
 
 .select-input {
@@ -129,11 +129,11 @@
 }
 
 .selected .dropdown-icon {
-  --icon-color: var(--bl-color-neutral-darker);
+  --icon-color: var(--bl-color-foreground-primary);
 }
 
 :host([disabled]) .dropdown-icon {
-  --icon-color: var(--bl-color-neutral-light);
+  --icon-color: var(--bl-color-foreground-disabled);
 }
 
 .select-open .select-input,
@@ -163,7 +163,7 @@
 }
 
 :host([disabled]) .select-input .selected-options {
-  color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-disabled);
 }
 
 .selected-options li {
@@ -187,11 +187,11 @@
 }
 
 :host([disabled]) .additional-selection-count {
-  color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-disabled);
 }
 
 :host([disabled]) .selected-options li {
-  color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-disabled);
 }
 
 .select-input .actions {
@@ -335,11 +335,11 @@ legend span {
 .dirty.invalid label,
 .invalid-text,
 .error-icon {
-  color: var(--bl-color-danger);
+  color: var(--bl-color-text-danger);
 }
 
 .help-text {
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
 }
 
 .select-open .help-text,
@@ -377,7 +377,7 @@ legend span {
   content: "";
   width: 100%;
   bottom: 0;
-  border-bottom: 1px solid var(--bl-color-neutral-lighter);
+  border-bottom: 1px solid var(--bl-color-border-primary);
 }
 
 .search-bar-input {
@@ -414,7 +414,7 @@ legend span {
   display: block;
   height: 1rem;
   width: 1px;
-  background-color: var(--bl-color-neutral-lighter);
+  background-color: var(--bl-color-border-primary);
 }
 
 .actions bl-icon {

--- a/src/components/select/bl-select.ts
+++ b/src/components/select/bl-select.ts
@@ -410,7 +410,7 @@ export default class BlSelect<ValueType extends FormValue = string> extends Form
     const searchMagIcon = html`<bl-icon
       class="search-mag-icon"
       name="search"
-      style="color: var(--bl-color-primary);font-size: var(--bl-font-size-s)"
+      style="color: var(--bl-color-foreground-brand);font-size: var(--bl-font-size-s)"
     ></bl-icon>`;
 
     const searchSpinner = html`<bl-spinner class="search-spinner"></bl-spinner>`;

--- a/src/components/select/option/bl-select-option.css
+++ b/src/components/select/option/bl-select-option.css
@@ -5,11 +5,11 @@
 .option-container {
   --option-font: var(--bl-font-title-3-regular);
   --option-spacing: var(--bl-size-xs) 0;
-  --option-selected-color: var(--bl-color-primary);
-  --option-hover-color: var(--bl-color-primary-highlight);
-  --option-color: var(--bl-color-neutral-darker);
-  --option-disabled-color: var(--bl-color-neutral-light);
-  --option-separator: 1px solid var(--bl-color-neutral-lighter);
+  --option-selected-color: var(--bl-color-text-brand);
+  --option-hover-color: var(--bl-color-text-brand-hover);
+  --option-color: var(--bl-color-text-primary);
+  --option-disabled-color: var(--bl-color-text-disabled);
+  --option-separator: 1px solid var(--bl-color-border-primary);
   --option-gap: var(--bl-size-2xs);
   --option-transition: color 120ms ease-out;
 }

--- a/src/components/spinner/bl-spinner.css
+++ b/src/components/spinner/bl-spinner.css
@@ -17,7 +17,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: rgba(39 49 66 / 70%);
+  background-color: rgb(41 46 50 / 70%);
   z-index: 10;
 }
 

--- a/src/components/spinner/bl-spinner.stories.mdx
+++ b/src/components/spinner/bl-spinner.stories.mdx
@@ -85,9 +85,9 @@ This example demonstrates the spinner with different color properties.
   <Story name="Spinner Colors">
     {(args) => html`
       <div style="display: flex; gap: 16px;">
-        ${SingleSpinnerTemplate({ color: "var(--bl-color-info-highlight)", ...args })}
-        ${SingleSpinnerTemplate({ color: "var(--bl-color-danger)", ...args })}
-        ${SingleSpinnerTemplate({ color: "var(--bl-color-success)", ...args })}
+        ${SingleSpinnerTemplate({ color: "var(--bl-color-foreground-info-hover)", ...args })}
+        ${SingleSpinnerTemplate({ color: "var(--bl-color-foreground-danger)", ...args })}
+        ${SingleSpinnerTemplate({ color: "var(--bl-color-foreground-success)", ...args })}
       </div>
     `}
   </Story>

--- a/src/components/spinner/bl-spinner.test.ts
+++ b/src/components/spinner/bl-spinner.test.ts
@@ -16,7 +16,7 @@ describe("bl-spinner", () => {
 
     assert.shadowDom.equal(
       el,
-      "<bl-icon class=\"spinner\" name=\"loading\" style=\"color: var(--bl-color-primary); font-size: var(--bl-font-size-m);\"></bl-icon>"
+      "<bl-icon class=\"spinner\" name=\"loading\" style=\"color: var(--bl-color-foreground-brand); font-size: var(--bl-font-size-m);\"></bl-icon>"
     );
   });
 
@@ -26,7 +26,7 @@ describe("bl-spinner", () => {
     expect(el.size).to.equal("var(--bl-font-size-m)");
     expect(el.disabled).to.equal(false);
     expect(el.overlay).to.equal(false);
-    expect(el.color).to.equal("var(--bl-color-primary)");
+    expect(el.color).to.equal("var(--bl-color-foreground-brand)");
   });
 
   it("sets spinner size", async () => {
@@ -41,14 +41,14 @@ describe("bl-spinner", () => {
   });
 
   it("sets spinner color", async () => {
-    const el = await fixture<typeOfBlSpinner>(html`<bl-spinner color="var(--bl-color-secondary)"></bl-spinner>`);
+    const el = await fixture<typeOfBlSpinner>(html`<bl-spinner color="red"></bl-spinner>`);
 
     await elementUpdated(el);
 
-    expect(el.color).to.equal("var(--bl-color-secondary)");
+    expect(el.color).to.equal("red");
     const spinner = el.shadowRoot?.querySelector("bl-icon");
 
-    expect(spinner?.style.color).to.equal("var(--bl-color-secondary)");
+    expect(spinner?.style.color).to.equal("red");
   });
 
   it("sets disabled state", async () => {
@@ -59,7 +59,7 @@ describe("bl-spinner", () => {
     expect(el.disabled).to.equal(true);
     const spinner = el.shadowRoot?.querySelector("bl-icon");
 
-    expect(spinner?.style.color).to.equal("var(--bl-color-neutral-light)");
+    expect(spinner?.style.color).to.equal("var(--bl-color-foreground-disabled)");
   });
 
   it("sets overlay state", async () => {
@@ -84,7 +84,7 @@ describe("bl-spinner", () => {
     expect(style.position).to.equal("absolute");
     expect(style.top).to.equal("0px");
     expect(style.left).to.equal("0px");
-    expect(style.backgroundColor).to.equal("rgba(39, 49, 66, 0.7)");
+    expect(style.backgroundColor).to.equal("rgba(41, 46, 50, 0.7)");
     expect(style.zIndex).to.equal("10");
   });
 

--- a/src/components/spinner/bl-spinner.ts
+++ b/src/components/spinner/bl-spinner.ts
@@ -37,14 +37,14 @@ export default class BlSpinner extends LitElement {
    * Sets the color of the spinner
    */
   @property({ type: String, reflect: true })
-  color: string = "var(--bl-color-primary)";
+  color: string = "var(--bl-color-foreground-brand)";
 
   render(): TemplateResult {
     return html`<bl-icon
       class="spinner"
       name="loading"
       style="color: ${this.disabled
-        ? "var(--bl-color-neutral-light)"
+        ? "var(--bl-color-foreground-disabled)"
         : this.color}; font-size: ${this.size};"
     ></bl-icon>`;
   }

--- a/src/components/split-button/bl-split-button.css
+++ b/src/components/split-button/bl-split-button.css
@@ -4,15 +4,15 @@
 }
 
 :host([kind="neutral"]) bl-popover {
-  --bl-popover-border-color: var(--bl-color-neutral-darker);
+  --bl-popover-border-color: var(--bl-color-border-neutral);
 }
 
 :host([kind="success"]) bl-popover {
-  --bl-popover-border-color: var(--bl-color-success);
+  --bl-popover-border-color: var(--bl-color-border-success);
 }
 
 :host([kind="danger"]) bl-popover {
-  --bl-popover-border-color: var(--bl-color-danger);
+  --bl-popover-border-color: var(--bl-color-border-danger);
 }
 
 .split-button-container {
@@ -65,7 +65,7 @@
   display: block;
   height: var(--bl-size-2xl);
   width: 1px;
-  background-color: var(--bl-color-neutral-full);
+  background-color: var(--bl-color-background-primary);
 }
 
 :host([variant="secondary"]) .split-divider {
@@ -82,5 +82,5 @@
 
 :host([dropdown-disabled][disabled]) .split-divider {
   display: block;
-  background-color: var(--bl-color-neutral-lighter);
+  background-color: var(--bl-color-border-primary);
 }

--- a/src/components/stepper/bl-stepper-item.css
+++ b/src/components/stepper/bl-stepper-item.css
@@ -5,17 +5,17 @@
 }
 
 .stepper-item {
-  --item-color: var(--bl-color-neutral-light);
-  --item-background: var(--bl-color-neutral-full);
-  --active-color: var(--bl-color-primary);
-  --hover-color: var(--bl-color-primary-highlight);
-  --success-color: var(--bl-color-success);
-  --error-color: var(--bl-color-danger);
-  --disabled-color: var(--bl-color-neutral-lighter);
-  --text-color-active: var(--bl-color-primary);
-  --text-color-default: var(--bl-color-neutral-light);
-  --description-color-active: var(--bl-color-neutral-darker);
-  --description-color-default: var(--bl-color-neutral-light);
+  --item-color: var(--bl-color-foreground-placeholder);
+  --item-background: var(--bl-color-background-primary);
+  --active-color: var(--bl-color-foreground-brand);
+  --hover-color: var(--bl-color-foreground-brand-hover);
+  --success-color: var(--bl-color-foreground-success);
+  --error-color: var(--bl-color-foreground-danger);
+  --disabled-color: var(--bl-color-foreground-disabled);
+  --text-color-active: var(--bl-color-text-brand);
+  --text-color-default: var(--bl-color-text-placeholder);
+  --description-color-active: var(--bl-color-text-primary);
+  --description-color-default: var(--bl-color-text-placeholder);
 
   display: flex;
   align-items: flex-start;
@@ -79,13 +79,13 @@
 }
 
 .connector {
-  background-color: var(--bl-color-neutral-lighter);
+  background-color: var(--bl-color-border-primary);
   transition: background-color 0.2s ease;
   flex-shrink: 0;
 }
 
 .connector.completed {
-  background-color: var(--bl-color-neutral-darker);
+  background-color: var(--bl-color-foreground-primary);
 }
 
 .stepper-item.direction-horizontal .connector {
@@ -247,7 +247,7 @@
 }
 
 .stepper-item.clickable:focus-visible .stepper-indicator {
-  outline: 2px solid var(--bl-color-primary);
+  outline: 2px solid var(--bl-color-border-brand);
   outline-offset: 2px;
 }
 
@@ -329,44 +329,44 @@
 .stepper-item.variant-active.type-number .stepper-indicator {
   border-color: var(--active-color);
   background-color: var(--active-color);
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
 }
 
 .stepper-item.variant-success.type-number .stepper-indicator {
   border-color: var(--success-color);
   background-color: var(--success-color);
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
 }
 
 .stepper-item.variant-error.type-number .stepper-indicator {
   border-color: var(--error-color);
   background-color: var(--error-color);
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
 }
 
 .stepper-item.variant-default.type-icon .stepper-indicator {
   background-color: var(--item-color);
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
 }
 
 .stepper-item.variant-hover.type-icon .stepper-indicator {
   background-color: var(--active-color);
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
 }
 
 .stepper-item.variant-active.type-icon .stepper-indicator {
   background-color: var(--active-color);
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
 }
 
 .stepper-item.variant-success.type-icon .stepper-indicator {
   background-color: var(--success-color);
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
 }
 
 .stepper-item.variant-error.type-icon .stepper-indicator {
   background-color: var(--error-color);
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
 }
 
 :host([dir="rtl"]) .stepper-item.direction-horizontal {

--- a/src/components/switch/bl-switch.css
+++ b/src/components/switch/bl-switch.css
@@ -17,7 +17,7 @@ span {
 
   /* TODO: use predefined animation duration once it is ready */
   --animation-duration: var(--bl-switch-animation-duration, 300ms);
-  --switch-color: var(--bl-switch-color-off, var(--bl-color-neutral-lighter));
+  --switch-color: var(--bl-switch-color-off, var(--bl-color-border-primary));
 
   background-color: var(--switch-color);
   border-radius: var(--bl-border-radius-pill);
@@ -44,7 +44,7 @@ span {
 label {
   display: flex;
   gap: var(--bl-size-2xs);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   font: var(--bl-font-title-3);
   cursor: pointer;
   user-select: none;
@@ -58,17 +58,17 @@ label {
 }
 
 :host([disabled]) .label {
-  color: var(--bl-color-neutral-light);
-  border: 1px solid var(--bl-color-neutral-lighter);
+  color: var(--bl-color-text-disabled);
+  border: 1px solid var(--bl-color-border-disabled);
 }
 
 :host([checked]) .label,
 :host(:hover) .label {
-  color: var(--bl-color-primary);
+  color: var(--bl-color-text-brand);
 }
 
 :host([checked]) .switch {
-  --switch-color: var(--bl-switch-color-on, var(--bl-switch-color, var(--bl-color-primary)));
+  --switch-color: var(--bl-switch-color-on, var(--bl-switch-color, var(--bl-color-foreground-brand)));
 }
 
 :host([checked]) .switch::before {

--- a/src/components/switch/bl-switch.css
+++ b/src/components/switch/bl-switch.css
@@ -68,7 +68,10 @@ label {
 }
 
 :host([checked]) .switch {
-  --switch-color: var(--bl-switch-color-on, var(--bl-switch-color, var(--bl-color-foreground-brand)));
+  --switch-color: var(
+    --bl-switch-color-on,
+    var(--bl-switch-color, var(--bl-color-foreground-brand))
+  );
 }
 
 :host([checked]) .switch::before {

--- a/src/components/switch/bl-switch.stories.mdx
+++ b/src/components/switch/bl-switch.stories.mdx
@@ -116,8 +116,8 @@ We strongly advise against customizing switch with any colors other than success
     args={{
       class: 'colored-switch-1',
       styles: {
-        '--bl-switch-color-on': 'var(--bl-color-success)',
-        '--bl-switch-color-off': 'var(--bl-color-danger)',
+        '--bl-switch-color-on': 'var(--bl-color-foreground-success)',
+        '--bl-switch-color-off': 'var(--bl-color-foreground-danger)',
       },
     }}
   >
@@ -128,8 +128,8 @@ We strongly advise against customizing switch with any colors other than success
     args={{
       class: 'colored-switch-2',
       styles: {
-        '--bl-switch-color-on': 'var(--bl-color-success)',
-        '--bl-switch-color-off': 'var(--bl-color-danger)',
+        '--bl-switch-color-on': 'var(--bl-color-foreground-success)',
+        '--bl-switch-color-off': 'var(--bl-color-foreground-danger)',
       },
       checked: true,
     }}

--- a/src/components/switch/bl-switch.ts
+++ b/src/components/switch/bl-switch.ts
@@ -11,8 +11,8 @@ export const blSwitchTag = "bl-switch";
  * @tag bl-switch
  * @summary Baklava Switch component
  *
- * @cssproperty [--bl-switch-color-on=--bl-color-primary] Set the checked color
- * @cssproperty [--bl-switch-color-off=--bl-color-neutral-lighter] Set the unchecked color
+ * @cssproperty [--bl-switch-color-on=--bl-color-foreground-brand] Set the checked color
+ * @cssproperty [--bl-switch-color-off=--bl-color-border-primary] Set the unchecked color
  * @cssproperty [--bl-switch-animation-duration=300ms] Set the animation duration of switch toggle
  */
 @customElement(blSwitchTag)

--- a/src/components/switch/doc/ADR.md
+++ b/src/components/switch/doc/ADR.md
@@ -60,4 +60,4 @@ Description
 
 | Property | Description | Default Value |
 | --------------- | --------------- | --------------- |
-| `—bl-switch-color` | The color of the Switch | --bl-color-primary (when `checked`) |
+| `—bl-switch-color` | The color of the Switch | --bl-color-foreground-brand (when `checked`) |

--- a/src/components/tab-group/bl-tab-group.css
+++ b/src/components/tab-group/bl-tab-group.css
@@ -1,6 +1,6 @@
 .tabs {
-  background-color: var(--bl-color-neutral-full);
-  border-bottom: var(--bl-size-4xs) solid var(--bl-color-neutral-lightest);
+  background-color: var(--bl-color-background-primary);
+  border-bottom: var(--bl-size-4xs) solid var(--bl-color-background-tertiary);
   display: flex;
   flex-direction: row;
 }

--- a/src/components/tab-group/doc/ADR.md
+++ b/src/components/tab-group/doc/ADR.md
@@ -38,8 +38,8 @@ General usage example:
 ```html
 <style>
 .tab-badge-new {
-   --bl-badge-color: var(--bl-color-primary-background);
-   --bl-badge-bg-color: var(--bl-color-danger);
+   --bl-badge-color: var(--bl-color-text-brand);
+   --bl-badge-bg-color: var(--bl-color-background-danger);
 }
 </style>
 

--- a/src/components/tab-group/tab-panel/bl-tab-panel.css
+++ b/src/components/tab-group/tab-panel/bl-tab-panel.css
@@ -1,6 +1,6 @@
 div {
   padding: var(--bl-size-xl);
-  background-color: var(--bl-color-neutral-full);
+  background-color: var(--bl-color-background-primary);
   border-radius: 0 0 var(--bl-border-radius-m) var(--bl-border-radius-m);
 }
 

--- a/src/components/tab-group/tab/bl-tab.css
+++ b/src/components/tab-group/tab/bl-tab.css
@@ -2,15 +2,15 @@
   position: relative;
   display: flex;
   align-items: center;
-  background-color: var(--bl-color-neutral-full);
+  background-color: var(--bl-color-background-primary);
 }
 
 .container {
   --title-padding-vertical: var(--bl-size-m);
   --title-padding-horizontal: var(--bl-size-xl);
-  --title-color: var(--bl-color-neutral-darker);
-  --caption-color: var(--bl-color-neutral-darker);
-  --icon-color: var(--bl-color-neutral-darker);
+  --title-color: var(--bl-color-text-primary);
+  --caption-color: var(--bl-color-text-primary);
+  --icon-color: var(--bl-color-foreground-primary);
   --border-bottom-width: var(--bl-size-4xs);
   --border-left-space: var(--bl-size-xl);
   --font-title: var(--bl-font-title-3-medium);
@@ -35,7 +35,7 @@
   inset-inline-end: 0;
   top: var(--bl-size-m);
   height: calc(100% - var(--bl-size-2xl));
-  border-inline-end: 1px solid var(--bl-color-neutral-lighter);
+  border-inline-end: 1px solid var(--bl-color-border-primary);
 }
 
 :host(:last-of-type) .container::after {
@@ -48,7 +48,7 @@
 
 :host(:focus-visible) .container,
 .container:focus-visible {
-  outline: 2px solid var(--bl-color-primary);
+  outline: 2px solid var(--bl-color-border-brand);
   outline-offset: calc(-1 * var(--bl-size-3xs));
   border-radius: var(--bl-border-radius-s);
 }
@@ -60,7 +60,7 @@
   bottom: calc(-1 * var(--bl-size-4xs));
   inset-inline-start: var(--border-left-space);
   width: calc(100% - var(--bl-size-4xl));
-  border-bottom: var(--border-bottom-width) solid var(--bl-color-primary);
+  border-bottom: var(--border-bottom-width) solid var(--bl-color-border-brand);
 }
 
 :host([selected]:not([disabled])) .container::before {
@@ -69,16 +69,16 @@
 
 :host(:hover) .container,
 :host([selected]) .container {
-  --title-color: var(--bl-color-primary);
-  --icon-color: var(--bl-color-primary);
+  --title-color: var(--bl-color-text-brand);
+  --icon-color: var(--bl-color-foreground-brand);
 }
 
 :host([disabled]) .container {
   cursor: not-allowed;
 
-  --title-color: var(--bl-color-neutral-lighter);
-  --caption-color: var(--bl-color-neutral-lighter);
-  --icon-color: var(--bl-color-neutral-lighter);
+  --title-color: var(--bl-color-text-disabled);
+  --caption-color: var(--bl-color-text-disabled);
+  --icon-color: var(--bl-color-foreground-disabled);
 }
 
 :host(:hover) :where(.title, .icon) {
@@ -164,6 +164,6 @@ bl-tooltip {
   width: var(--bl-size-2xs);
   border-radius: var(--bl-size-3xs);
   margin-inline-start: var(--bl-size-3xs);
-  background-color: var(--bl-color-danger);
+  background-color: var(--bl-color-foreground-danger);
   margin-bottom: 1px;
 }

--- a/src/components/table/bl-table.css
+++ b/src/components/table/bl-table.css
@@ -5,7 +5,7 @@
 
 .table-wrapper {
   overflow: auto;
-  border: 1px solid var(--bl-color-neutral-lighter);
+  border: 1px solid var(--bl-color-border-primary);
   border-radius: var(--bl-size-3xs);
   position: relative;
   max-height: 100%;

--- a/src/components/table/bl-table.stories.mdx
+++ b/src/components/table/bl-table.stories.mdx
@@ -705,9 +705,9 @@ export const EmptyTableTemplate = (args) => html`
         ${args.showNoDataSlot ? html`
           <div slot="no-data">
             <div style="display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 200px;">
-              <bl-icon name="archive" style="font-size: 32px; margin-bottom: var(--bl-size-l); color: var(--bl-color-primary);"></bl-icon>
-              <p style="margin: 0; font: var(--bl-font-title-2-medium); color: var(--bl-color-neutral-darker);">Custom Empty State</p>
-              <p style="margin: var(--bl-size-xs) 0 0 0; font: var(--bl-font-body-text-2); color: var(--bl-color-neutral-light);">This is a custom no-data slot implementation.</p>
+              <bl-icon name="archive" style="font-size: 32px; margin-bottom: var(--bl-size-l); color: var(--bl-color-foreground-brand);"></bl-icon>
+              <p style="margin: 0; font: var(--bl-font-title-2-medium); color: var(--bl-color-text-primary);">Custom Empty State</p>
+              <p style="margin: var(--bl-size-xs) 0 0 0; font: var(--bl-font-body-text-2); color: var(--bl-color-text-placeholder);">This is a custom no-data slot implementation.</p>
               <bl-button style="margin-top: var(--bl-size-l);">
                 Add New Item
               </bl-button>

--- a/src/components/table/table-body/bl-table-body.css
+++ b/src/components/table/table-body/bl-table-body.css
@@ -11,7 +11,7 @@
   padding: var(--bl-size-2xl);
   text-align: center;
   vertical-align: middle;
-  background-color: var(--bl-color-neutral-full);
+  background-color: var(--bl-color-background-primary);
   width: 100%;
   min-height: 250px;
   position: relative;
@@ -33,17 +33,17 @@
 .default-no-data bl-icon {
   font-size: 48px;
   margin-bottom: var(--bl-size-m);
-  color: var(--bl-color-neutral-light);
+  color: var(--bl-color-foreground-placeholder);
 }
 
 .default-no-data .title {
   margin: 0;
   font: var(--bl-font-title-2-regular);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
 }
 
 .default-no-data .subtitle {
   margin: var(--bl-size-xs) 0 0 0;
   font: var(--bl-font-body-text-2);
-  color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-placeholder);
 }

--- a/src/components/table/table-cell/bl-table-cell.css
+++ b/src/components/table/table-cell/bl-table-cell.css
@@ -1,13 +1,13 @@
 :host {
   display: table-cell;
-  border: 1px solid var(--bl-color-neutral-lighter);
+  border: 1px solid var(--bl-color-border-primary);
   padding: var(--bl-size-m);
   font: var(--bl-font-title-3-regular);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   box-sizing: border-box;
   vertical-align: middle;
   word-break: break-word;
-  background-color: var(--bl-color-neutral-full);
+  background-color: var(--bl-color-background-primary);
   background-clip: padding-box;
   border-top: none;
   border-inline-end: none;
@@ -26,7 +26,7 @@
   width: 16px;
   height: 100%;
   z-index: -1;
-  border-inline-end: 1px solid var(--bl-color-neutral-lighter);
+  border-inline-end: 1px solid var(--bl-color-border-primary);
   box-shadow: calc(8px * var(--bl-text-x-direction)) 0 16px 0 rgb(39 49 66 / 10%);
 }
 
@@ -38,7 +38,7 @@
   width: 16px;
   height: 100%;
   z-index: -1;
-  border-inline-start: 1px solid var(--bl-color-neutral-lighter);
+  border-inline-start: 1px solid var(--bl-color-border-primary);
   box-shadow: calc(-8px * var(--bl-text-x-direction)) 0 16px 0 rgb(39 49 66 / 10%);
 }
 

--- a/src/components/table/table-header-cell/bl-table-header-cell.css
+++ b/src/components/table/table-header-cell/bl-table-header-cell.css
@@ -3,11 +3,11 @@
   --header-cell-min-width: var(--bl-table-header-cell-min-width, auto);
 
   display: table-cell;
-  border: 1px solid var(--bl-color-neutral-lighter);
-  background-color: var(--bl-color-neutral-lightest);
+  border: 1px solid var(--bl-color-border-primary);
+  background-color: var(--bl-color-background-tertiary);
   padding: var(--bl-size-m);
   font: var(--bl-font-title-3-medium);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   box-sizing: border-box;
   vertical-align: middle;
   white-space: normal;
@@ -29,7 +29,7 @@
   width: 16px;
   height: 100%;
   z-index: -1;
-  border-inline-end: 1px solid var(--bl-color-neutral-lighter);
+  border-inline-end: 1px solid var(--bl-color-border-primary);
   box-shadow: calc(8px * var(--bl-text-x-direction)) 0 16px 0 rgb(39 49 66 / 10%);
 }
 
@@ -41,7 +41,7 @@
   width: 16px;
   height: 100%;
   z-index: -1;
-  border-inline-start: 1px solid var(--bl-color-neutral-lighter);
+  border-inline-start: 1px solid var(--bl-color-border-primary);
   box-shadow: calc(-8px * var(--bl-text-x-direction)) 0 16px 0 rgb(39 49 66 / 10%);
 }
 
@@ -60,12 +60,12 @@ bl-checkbox {
 }
 
 .sort-icons-wrapper:focus-visible {
-  outline: 2px solid var(--bl-color-primary);
+  outline: 2px solid var(--bl-color-border-brand);
   outline-offset: 2px;
   border-radius: var(--bl-border-radius-xs);
 }
 
 .sort-icons-wrapper bl-icon {
   font-size: var(--bl-font-size-m);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-foreground-primary);
 }

--- a/src/components/table/table-header/bl-table-header.css
+++ b/src/components/table/table-header/bl-table-header.css
@@ -20,5 +20,5 @@
   inset-inline-start: 0;
   inset-inline-end: 0;
   height: 1px;
-  background: var(--bl-color-neutral-lighter);
+  background: var(--bl-color-border-primary);
 }

--- a/src/components/table/table-row/bl-table-row.css
+++ b/src/components/table/table-row/bl-table-row.css
@@ -4,18 +4,18 @@
 
 :host([checked]),
 :host([checked]) ::slotted(bl-table-cell) {
-  background-color: var(--bl-color-primary-contrast);
+  background-color: var(--bl-color-background-brand);
 }
 
 :host([disabled]),
 :host([disabled]) ::slotted(bl-table-cell) {
-  background-color: var(--bl-color-neutral-lightest);
-  color: var(--bl-color-neutral-light);
+  background-color: var(--bl-color-background-disabled);
+  color: var(--bl-color-text-disabled);
 }
 
 :host(:not([checked], [disabled]):hover),
 :host(:not([checked], [disabled]):hover) ::slotted(bl-table-cell) {
-  background-color: var(--bl-color-tertiary-background);
+  background-color: var(--bl-color-background-tertiary);
 }
 
 :host ::slotted(*:first-child) {

--- a/src/components/tag/bl-tag.css
+++ b/src/components/tag/bl-tag.css
@@ -4,8 +4,8 @@
 }
 
 .tag {
-  --bg-color: var(--bl-color-neutral-full);
-  --color: var(--bl-color-neutral-darker);
+  --bg-color: var(--bl-color-background-primary);
+  --color: var(--bl-color-text-primary);
   --font: var(--bl-font-title-4-medium);
   --padding-vertical: var(--bl-size-2xs);
   --padding-horizontal: var(--bl-size-xs);
@@ -22,7 +22,7 @@
   box-sizing: border-box;
   overflow: hidden;
   width: 100%;
-  border: 1px solid var(--bl-color-neutral-lighter);
+  border: 1px solid var(--bl-color-border-primary);
   border-radius: var(--border-radius);
   padding-block: var(--padding-vertical);
   padding-inline: var(--padding-horizontal);
@@ -39,20 +39,20 @@
 }
 
 :host([variant="selectable"]) .tag:hover {
-  background-color: var(--bl-color-neutral-lightest);
+  background-color: var(--bl-color-background-tertiary);
 }
 
 :host([variant="selectable"][selected]) .tag {
-  border-color: var(--bl-color-neutral-darker);
-  background-color: var(--bl-color-neutral-darker);
+  border-color: var(--bl-color-border-neutral);
+  background-color: var(--bl-color-foreground-primary);
 
-  --color: var(--bl-color-neutral-full);
+  --color: var(--bl-color-foreground-primary-on-color);
 }
 
 :host([variant="selectable"][disabled]) .tag {
-  background-color: var(--bl-color-neutral-lightest);
-  border-color: var(--bl-color-neutral-lightest);
-  color: var(--bl-color-neutral-light);
+  background-color: var(--bl-color-background-disabled);
+  border-color: var(--bl-color-background-disabled);
+  color: var(--bl-color-text-disabled);
   cursor: not-allowed;
 }
 

--- a/src/components/textarea/bl-textarea.css
+++ b/src/components/textarea/bl-textarea.css
@@ -17,8 +17,8 @@
   --height: max(var(--scroll-height), var(--default-scroll-height));
   --input-font: var(--bl-font-body-text-2);
   --border-radius: var(--bl-size-3xs);
-  --border-color: var(--bl-color-neutral-lighter);
-  --background-color: var(--bl-color-neutral-full);
+  --border-color: var(--bl-color-border-primary);
+  --background-color: var(--bl-color-background-primary);
 
   display: flex;
   flex-direction: column;
@@ -51,7 +51,7 @@ textarea {
   margin: 0 calc(-1 * var(--parent-padding));
   border: none;
   border-radius: var(--border-radius);
-  color: var(--bl-color-neutral-darker);
+  color: var(--bl-color-text-primary);
   resize: vertical;
   background-color: transparent;
   display: block;
@@ -70,13 +70,13 @@ textarea {
 }
 
 textarea:disabled {
-  background-color: var(--bl-color-neutral-lightest);
-  color: var(--bl-color-neutral-light);
+  background-color: var(--bl-color-background-disabled);
+  color: var(--bl-color-text-disabled);
   cursor: not-allowed;
 }
 
 :host([disabled]) .wrapper {
-  --background-color: var(--bl-color-neutral-lightest);
+  --background-color: var(--bl-color-background-disabled);
 }
 
 :host([expand]) textarea {
@@ -93,12 +93,12 @@ textarea:disabled {
 }
 
 .wrapper:focus-within {
-  --border-color: var(--bl-color-primary);
+  --border-color: var(--bl-color-border-brand);
 }
 
 .dirty.max-len-invalid,
 .dirty.invalid {
-  --border-color: var(--bl-color-danger);
+  --border-color: var(--bl-color-border-danger);
 }
 
 :host([label]) ::placeholder {
@@ -123,7 +123,7 @@ label {
   inset-inline-start: var(--padding-horizontal);
   inset-inline-end: var(--padding-horizontal);
   pointer-events: none;
-  color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-placeholder);
 }
 
 .input-wrapper legend {
@@ -144,7 +144,7 @@ label {
   inset-inline-start: var(--padding-horizontal);
   transform: translateY(-50%);
   font: var(--bl-font-caption);
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
   pointer-events: initial;
   z-index: var(--bl-index-base);
 }
@@ -157,7 +157,7 @@ label {
 
 :host ::placeholder,
 :host([label-fixed]) ::placeholder {
-  color: var(--bl-color-neutral-light);
+  color: var(--bl-color-text-placeholder);
 }
 
 :host([label-fixed]) label {
@@ -166,7 +166,7 @@ label {
   transform: none;
   pointer-events: initial;
   font: var(--bl-font-caption);
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
   background-color: initial;
   padding: 0;
 }
@@ -198,25 +198,25 @@ label {
 }
 
 .counter-text {
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
   margin-inline-start: auto;
 }
 
 :where(.max-len-invalid, .dirty.invalid) .hint > .counter-text {
-  color: var(--bl-color-danger);
+  color: var(--bl-color-text-danger);
 }
 
 .dirty.invalid label {
-  color: var(--bl-color-danger);
+  color: var(--bl-color-text-danger);
 }
 
 .invalid-text {
   display: none;
-  color: var(--bl-color-danger);
+  color: var(--bl-color-text-danger);
 }
 
 .help-text {
-  color: var(--bl-color-neutral-dark);
+  color: var(--bl-color-text-secondary);
 }
 
 :where(.dirty.max-len-invalid, .dirty.invalid) .hint > .invalid-text {

--- a/src/components/tooltip/bl-tooltip.css
+++ b/src/components/tooltip/bl-tooltip.css
@@ -8,12 +8,12 @@
 }
 
 bl-popover {
-  --bl-popover-background-color: var(--bl-color-info);
+  --bl-popover-background-color: var(--bl-color-foreground-info);
   --bl-popover-arrow-display: block;
   --bl-popover-border-size: 0px;
   --bl-popover-max-width: 424px;
 }
 
 .content {
-  color: var(--bl-color-neutral-full);
+  color: var(--bl-color-foreground-primary-on-color);
 }

--- a/src/themes/dark.css
+++ b/src/themes/dark.css
@@ -14,40 +14,75 @@
 
 :root[data-theme="dark"],
 .dark-theme {
-  /* Neutral Colors - Dark Mode */
-  --bl-color-neutral-none: #f0f5ff;
-  --bl-color-neutral-darkest: #f1f2f7;
-  --bl-color-neutral-darker: #afbbca;
-  --bl-color-neutral-dark: #95a1b5;
-  --bl-color-neutral-light: #6e7787;
-  --bl-color-neutral-lighter: #273142;
-  --bl-color-neutral-lightest: #0f131a;
-  --bl-color-neutral-full: #030713;
+  /* Semantic Colors - Text */
+  --bl-color-text-primary: var(--bl-color-base-white);
+  --bl-color-text-primary-hover: var(--bl-color-neutral-100);
+  --bl-color-text-primary-on-color: var(--bl-color-neutral-950);
+  --bl-color-text-secondary: var(--bl-color-neutral-300);
+  --bl-color-text-placeholder: var(--bl-color-neutral-400);
+  --bl-color-text-disabled: var(--bl-color-neutral-500);
+  --bl-color-text-brand: var(--bl-color-brand-400);
+  --bl-color-text-brand-hover: var(--bl-color-brand-300);
+  --bl-color-text-info: var(--bl-color-info-400);
+  --bl-color-text-info-hover: var(--bl-color-info-300);
+  --bl-color-text-success: var(--bl-color-success-400);
+  --bl-color-text-success-hover: var(--bl-color-success-300);
+  --bl-color-text-warning: var(--bl-color-warning-400);
+  --bl-color-text-warning-hover: var(--bl-color-warning-300);
+  --bl-color-text-danger: var(--bl-color-danger-400);
+  --bl-color-text-danger-hover: var(--bl-color-danger-300);
+  --bl-color-text-accent: var(--bl-color-accent-400);
+  --bl-color-text-accent-hover: var(--bl-color-accent-300);
 
-  /* Primary Color - Slightly adjusted for dark mode */
-  --bl-color-primary: #fb882b;
-  --bl-color-primary-highlight: #d46b00;
-  --bl-color-primary-contrast: #1f1d18;
+  /* Semantic Colors - Border */
+  --bl-color-border-primary: var(--bl-color-neutral-600);
+  --bl-color-border-primary-hover: var(--bl-color-brand-400);
+  --bl-color-border-primary-on-color: var(--bl-color-base-white);
+  --bl-color-border-divider: var(--bl-color-neutral-700);
+  --bl-color-border-disabled: var(--bl-color-neutral-700);
+  --bl-color-border-tertiary: var(--bl-color-neutral-900);
+  --bl-color-border-brand: var(--bl-color-brand-400);
+  --bl-color-border-info: var(--bl-color-info-400);
+  --bl-color-border-success: var(--bl-color-success-400);
+  --bl-color-border-warning: var(--bl-color-warning-400);
+  --bl-color-border-danger: var(--bl-color-danger-400);
+  --bl-color-border-neutral: var(--bl-color-base-white);
+  --bl-color-border-accent: var(--bl-color-accent-400);
 
-  /* Success Color - Adjusted for dark mode */
-  --bl-color-success: #3ac96b;
-  --bl-color-success-highlight: #00a84e;
-  --bl-color-success-contrast: #1a1e1a;
+  /* Semantic Colors - Foreground (non-text fills, icons) */
+  --bl-color-foreground-primary: var(--bl-color-base-white);
+  --bl-color-foreground-primary-hover: var(--bl-color-neutral-100);
+  --bl-color-foreground-primary-on-color: var(--bl-color-neutral-950);
+  --bl-color-foreground-secondary: var(--bl-color-neutral-300);
+  --bl-color-foreground-placeholder: var(--bl-color-neutral-400);
+  --bl-color-foreground-disabled: var(--bl-color-neutral-600);
+  --bl-color-foreground-tertiary: var(--bl-color-neutral-700);
+  --bl-color-foreground-brand: var(--bl-color-brand-400);
+  --bl-color-foreground-brand-hover: var(--bl-color-brand-300);
+  --bl-color-foreground-info: var(--bl-color-info-400);
+  --bl-color-foreground-info-hover: var(--bl-color-info-300);
+  --bl-color-foreground-success: var(--bl-color-success-400);
+  --bl-color-foreground-success-hover: var(--bl-color-success-300);
+  --bl-color-foreground-warning: var(--bl-color-warning-400);
+  --bl-color-foreground-warning-hover: var(--bl-color-warning-300);
+  --bl-color-foreground-danger: var(--bl-color-danger-400);
+  --bl-color-foreground-danger-hover: var(--bl-color-danger-300);
+  --bl-color-foreground-featured: var(--bl-color-accent-400);
+  --bl-color-foreground-featured-hover: var(--bl-color-accent-300);
 
-  /* Danger Color - Adjusted for dark mode */
-  --bl-color-danger: #fb8179;
-  --bl-color-danger-highlight: #d8625b;
-  --bl-color-danger-contrast: #211b1a;
-
-  /* Warning Color - Adjusted for dark mode */
-  --bl-color-warning: #e09b1a;
-  --bl-color-warning-highlight: #ba7f00;
-  --bl-color-warning-contrast: #1f1c18;
-
-  /* Info Color - Adjusted for dark mode */
-  --bl-color-info: #76aef5;
-  --bl-color-info-highlight: #588ed4;
-  --bl-color-info-contrast: #1a1d22;
+  /* Semantic Colors - Background */
+  --bl-color-background-primary: var(--bl-color-base-black);
+  --bl-color-background-primary-hover: var(--bl-color-neutral-950);
+  --bl-color-background-secondary: var(--bl-color-neutral-950);
+  --bl-color-background-tertiary: var(--bl-color-neutral-900);
+  --bl-color-background-disabled: var(--bl-color-neutral-900);
+  --bl-color-background-brand: var(--bl-color-brand-950);
+  --bl-color-background-info: var(--bl-color-info-950);
+  --bl-color-background-success: var(--bl-color-success-950);
+  --bl-color-background-warning: var(--bl-color-warning-950);
+  --bl-color-background-danger: var(--bl-color-danger-950);
+  --bl-color-background-accent: var(--bl-color-accent-950);
+  --bl-color-background-overlay: rgb(28 31 33 / 75%);
 
   /* Size and Spacing */
   --bl-size-4xs: 0.125rem; /* 2px */

--- a/src/themes/default.css
+++ b/src/themes/default.css
@@ -1,44 +1,175 @@
 @import url("@fontsource-variable/rubik");
 
+:root {
+  /* Primitive Colors - Neutral */
+  --bl-color-neutral-50: #f6f7f8;
+  --bl-color-neutral-100: #ebedf0;
+  --bl-color-neutral-150: #dce0e5;
+  --bl-color-neutral-200: #d0d6dc;
+  --bl-color-neutral-300: #b9c2ca;
+  --bl-color-neutral-400: #a2adb9;
+  --bl-color-neutral-500: #8b99a7;
+  --bl-color-neutral-600: #6a7a8a;
+  --bl-color-neutral-700: #515c67;
+  --bl-color-neutral-800: #394047;
+  --bl-color-neutral-900: #292e32;
+  --bl-color-neutral-950: #1c1f21;
+
+  /* Primitive Colors - Brand */
+  --bl-color-brand-50: #fef4ec;
+  --bl-color-brand-100: #feeee2;
+  --bl-color-brand-200: #fcdec5;
+  --bl-color-brand-300: #f8b782;
+  --bl-color-brand-400: #f7974b;
+  --bl-color-brand-500: #f27a1a;
+  --bl-color-brand-600: #de670d;
+  --bl-color-brand-800: #813a08;
+  --bl-color-brand-900: #522205;
+  --bl-color-brand-950: #271002;
+
+  /* Primitive Colors - Success */
+  --bl-color-success-50: #e7f9ef;
+  --bl-color-success-100: #c5f1d9;
+  --bl-color-success-200: #92e7b8;
+  --bl-color-success-300: #4ddb8c;
+  --bl-color-success-400: #26c96f;
+  --bl-color-success-500: #14b85d;
+  --bl-color-success-600: #12a554;
+  --bl-color-success-700: #108e49;
+  --bl-color-success-800: #0c6e38;
+  --bl-color-success-900: #084523;
+  --bl-color-success-950: #042513;
+
+  /* Primitive Colors - Danger */
+  --bl-color-danger-50: #ffe7e5;
+  --bl-color-danger-100: #ffd0cc;
+  --bl-color-danger-200: #ffaea8;
+  --bl-color-danger-300: #ff928a;
+  --bl-color-danger-400: #ff7a70;
+  --bl-color-danger-500: #ff5043;
+  --bl-color-danger-600: #ff3028;
+  --bl-color-danger-700: #f01100;
+  --bl-color-danger-800: #bd0d00;
+  --bl-color-danger-900: #7a0800;
+  --bl-color-danger-950: #330300;
+
+  /* Primitive Colors - Warning */
+  --bl-color-warning-50: #fff8e6;
+  --bl-color-warning-100: #fff0cc;
+  --bl-color-warning-200: #ffe299;
+  --bl-color-warning-300: #ffd670;
+  --bl-color-warning-400: #ffc533;
+  --bl-color-warning-500: #ffb600;
+  --bl-color-warning-600: #faa700;
+  --bl-color-warning-700: #e59100;
+  --bl-color-warning-800: #cc7a00;
+  --bl-color-warning-900: #995700;
+  --bl-color-warning-950: #331d00;
+
+  /* Primitive Colors - Info */
+  --bl-color-info-50: #f0f5ff;
+  --bl-color-info-100: #dbe8ff;
+  --bl-color-info-200: #c7dcff;
+  --bl-color-info-300: #a8c8ff;
+  --bl-color-info-400: #7aabff;
+  --bl-color-info-500: #5794ff;
+  --bl-color-info-600: #3d84ff;
+  --bl-color-info-700: #2473ff;
+  --bl-color-info-800: #005dff;
+  --bl-color-info-950: #00163d;
+
+  /* Primitive Colors - Accent */
+  --bl-color-accent-50: #f5f0ff;
+  --bl-color-accent-100: #e8dbff;
+  --bl-color-accent-200: #d7c2ff;
+  --bl-color-accent-300: #bd99ff;
+  --bl-color-accent-400: #9c66ff;
+  --bl-color-accent-500: #8c4eff;
+  --bl-color-accent-600: #7e33ff;
+  --bl-color-accent-700: #7614ff;
+  --bl-color-accent-800: #6d00eb;
+  --bl-color-accent-900: #5900b8;
+  --bl-color-accent-950: #190033;
+
+  /* Primitive Colors - Base */
+  --bl-color-base-white: #ffffff;
+  --bl-color-base-black: #000000;
+}
+
 :root,
 :root[data-theme="light"] {
   /* Direction */
   --bl-text-x-direction: 1;
 
-  /* Primary Color */
-  --bl-color-primary: #f27a1a;
-  --bl-color-primary-highlight: #ef6114;
-  --bl-color-primary-contrast: #fef2e8;
+  /* Semantic Colors - Text */
+  --bl-color-text-primary: var(--bl-color-neutral-900);
+  --bl-color-text-primary-hover: var(--bl-color-neutral-950);
+  --bl-color-text-primary-on-color: var(--bl-color-base-white);
+  --bl-color-text-secondary: var(--bl-color-neutral-600);
+  --bl-color-text-placeholder: var(--bl-color-neutral-500);
+  --bl-color-text-disabled: var(--bl-color-neutral-400);
+  --bl-color-text-brand: var(--bl-color-brand-500);
+  --bl-color-text-brand-hover: var(--bl-color-brand-600);
+  --bl-color-text-info: var(--bl-color-info-500);
+  --bl-color-text-info-hover: var(--bl-color-info-600);
+  --bl-color-text-success: var(--bl-color-success-500);
+  --bl-color-text-success-hover: var(--bl-color-success-600);
+  --bl-color-text-warning: var(--bl-color-warning-500);
+  --bl-color-text-warning-hover: var(--bl-color-warning-600);
+  --bl-color-text-danger: var(--bl-color-danger-500);
+  --bl-color-text-danger-hover: var(--bl-color-danger-600);
+  --bl-color-text-accent: var(--bl-color-accent-500);
+  --bl-color-text-accent-hover: var(--bl-color-accent-600);
 
-  /* Success Color */
-  --bl-color-success: #0bc15c;
-  --bl-color-success-highlight: #09a44e;
-  --bl-color-success-contrast: #e7f9ef;
+  /* Semantic Colors - Border */
+  --bl-color-border-primary: var(--bl-color-neutral-300);
+  --bl-color-border-primary-hover: var(--bl-color-brand-500);
+  --bl-color-border-primary-on-color: var(--bl-color-base-white);
+  --bl-color-border-divider: var(--bl-color-neutral-200);
+  --bl-color-border-disabled: var(--bl-color-neutral-200);
+  --bl-color-border-tertiary: var(--bl-color-neutral-100);
+  --bl-color-border-brand: var(--bl-color-brand-500);
+  --bl-color-border-info: var(--bl-color-info-500);
+  --bl-color-border-success: var(--bl-color-success-500);
+  --bl-color-border-warning: var(--bl-color-warning-500);
+  --bl-color-border-danger: var(--bl-color-danger-500);
+  --bl-color-border-neutral: var(--bl-color-neutral-900);
+  --bl-color-border-accent: var(--bl-color-accent-500);
 
-  /* Danger Color */
-  --bl-color-danger: #ff5043;
-  --bl-color-danger-highlight: #ff3028;
-  --bl-color-danger-contrast: #ffeeec;
+  /* Semantic Colors - Foreground (non-text fills, icons) */
+  --bl-color-foreground-primary: var(--bl-color-neutral-900);
+  --bl-color-foreground-primary-hover: var(--bl-color-neutral-950);
+  --bl-color-foreground-primary-on-color: var(--bl-color-base-white);
+  --bl-color-foreground-secondary: var(--bl-color-neutral-600);
+  --bl-color-foreground-placeholder: var(--bl-color-neutral-500);
+  --bl-color-foreground-disabled: var(--bl-color-neutral-400);
+  --bl-color-foreground-tertiary: var(--bl-color-neutral-200);
+  --bl-color-foreground-brand: var(--bl-color-brand-500);
+  --bl-color-foreground-brand-hover: var(--bl-color-brand-600);
+  --bl-color-foreground-info: var(--bl-color-info-500);
+  --bl-color-foreground-info-hover: var(--bl-color-info-600);
+  --bl-color-foreground-success: var(--bl-color-success-500);
+  --bl-color-foreground-success-hover: var(--bl-color-success-600);
+  --bl-color-foreground-warning: var(--bl-color-warning-500);
+  --bl-color-foreground-warning-hover: var(--bl-color-warning-600);
+  --bl-color-foreground-danger: var(--bl-color-danger-500);
+  --bl-color-foreground-danger-hover: var(--bl-color-danger-600);
+  --bl-color-foreground-featured: var(--bl-color-accent-500);
+  --bl-color-foreground-featured-hover: var(--bl-color-accent-600);
 
-  /* Warning Color */
-  --bl-color-warning: #ffb600;
-  --bl-color-warning-highlight: #ff9800;
-  --bl-color-warning-contrast: #fff8e6;
-
-  /* Info Color */
-  --bl-color-info: #5794ff;
-  --bl-color-info-highlight: #457eff;
-  --bl-color-info-contrast: #eef4ff;
-
-  /* Neutral Color */
-  --bl-color-neutral-none: #000;
-  --bl-color-neutral-darkest: #0f131a;
-  --bl-color-neutral-darker: #273142;
-  --bl-color-neutral-dark: #6e7787;
-  --bl-color-neutral-light: #95a1b5;
-  --bl-color-neutral-lighter: #afbbca;
-  --bl-color-neutral-lightest: #f1f2f7;
-  --bl-color-neutral-full: #fff;
+  /* Semantic Colors - Background */
+  --bl-color-background-primary: var(--bl-color-base-white);
+  --bl-color-background-primary-hover: var(--bl-color-neutral-50);
+  --bl-color-background-secondary: var(--bl-color-neutral-50);
+  --bl-color-background-tertiary: var(--bl-color-neutral-100);
+  --bl-color-background-disabled: var(--bl-color-neutral-100);
+  --bl-color-background-brand: var(--bl-color-brand-50);
+  --bl-color-background-info: var(--bl-color-info-50);
+  --bl-color-background-success: var(--bl-color-success-50);
+  --bl-color-background-warning: var(--bl-color-warning-50);
+  --bl-color-background-danger: var(--bl-color-danger-50);
+  --bl-color-background-accent: var(--bl-color-accent-50);
+  --bl-color-background-overlay: rgb(28 31 33 / 75%);
 
   /* Size and Spacing */
   --bl-size-4xs: 0.125rem; /* 2px */

--- a/src/themes/default.css
+++ b/src/themes/default.css
@@ -92,8 +92,8 @@
   --bl-color-accent-950: #190033;
 
   /* Primitive Colors - Base */
-  --bl-color-base-white: #ffffff;
-  --bl-color-base-black: #000000;
+  --bl-color-base-white: #fff;
+  --bl-color-base-black: #000;
 }
 
 :root,


### PR DESCRIPTION
Replace the flat --bl-color-{role} token set with a two-tier system based on the Figma token library: a theme-agnostic primitive palette (neutral/brand/success/danger/warning/info/accent scales + base white/black) plus semantic tokens (text/border/foreground/background) that are remapped per theme in default.css and dark.css. All ~35 component stylesheets, a handful of .ts files, tests and docs/ADRs are migrated to the new --bl-color-{category}-{role}[-state] naming.

BREAKING CHANGE: old color tokens (--bl-color-primary, -highlight, -contrast, --bl-color-neutral-*, etc.) are removed with no aliases. Consumers overriding these tokens must switch to the new semantic token names (e.g. --bl-color-primary -> --bl-color-foreground-brand or --bl-color-text-brand depending on usage).