### PR TITLE
fix(pagination): clean up resize listener on disconnect

### DIFF
--- a/src/components/pagination/bl-pagination.test.ts
+++ b/src/components/pagination/bl-pagination.test.ts
@@ -1,4 +1,5 @@
 import { assert, expect, fixture, html, oneEvent } from "@open-wc/testing";
+import { spy } from "sinon";
 import BlPagination from "./bl-pagination";
 
 import type typeOfBlPagination from "./bl-pagination";
@@ -308,6 +309,39 @@ describe("bl-pagination", () => {
       select?.dispatchEvent(undefinedEvent);
 
       expect(el.itemsPerPage).to.equal(100);
+    });
+  });
+
+  describe("resize listener cleanup", () => {
+    it("should remove the exact same resize listener reference that was added on connect", async () => {
+      const addSpy = spy(window, "addEventListener");
+      const removeSpy = spy(window, "removeEventListener");
+
+      const el = await fixture<typeOfBlPagination>(html`<bl-pagination></bl-pagination>`);
+
+      // connectedCallback registers the resize listener inside a setTimeout(0)
+      await new Promise(resolve => setTimeout(resolve));
+
+      const resizeAddCall = addSpy.getCalls().find(call => call.args[0] === "resize");
+
+      expect(resizeAddCall, "resize listener should be registered on connect").to.exist;
+
+      const registeredHandler = resizeAddCall?.args[1] as EventListener;
+
+      window.dispatchEvent(new Event("resize"));
+
+      el.remove();
+
+      const resizeRemoveCall = removeSpy.getCalls().find(call => call.args[0] === "resize");
+
+      expect(resizeRemoveCall, "resize listener should be removed on disconnect").to.exist;
+      expect(
+        resizeRemoveCall?.args[1],
+        "removeEventListener must target the same handler reference that addEventListener used"
+      ).to.equal(registeredHandler);
+
+      addSpy.restore();
+      removeSpy.restore();
     });
   });
 });

--- a/src/components/pagination/bl-pagination.ts
+++ b/src/components/pagination/bl-pagination.ts
@@ -98,11 +98,13 @@ export default class BlPagination extends LitElement {
     itemsPerPage: number;
   }>;
 
+  private _handleResize = () => this._paginate();
+
   connectedCallback() {
     super.connectedCallback();
 
     setTimeout(() => {
-      window?.addEventListener("resize", () => this._paginate());
+      window?.addEventListener("resize", this._handleResize);
     });
 
     setDirectionProperty(this);
@@ -110,7 +112,7 @@ export default class BlPagination extends LitElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    window?.removeEventListener("resize", this._paginate);
+    window?.removeEventListener("resize", this._handleResize);
   }
 
   updated(changedProperties: PropertyValues<this>) {


### PR DESCRIPTION
## Summary

`bl-pagination`'s `connectedCallback` registers a `window` resize listener with a fresh anonymous arrow function:

```ts
window?.addEventListener("resize", () => this._paginate());
```

`disconnectedCallback` then tries to remove it with:

```ts
window?.removeEventListener("resize", this._paginate);
```

`this._paginate` is a different function reference from the one that was actually registered, so `removeEventListener` is a no-op. Every connect/disconnect cycle (conditional rendering, SPA navigation, etc.) leaves one more resize listener permanently attached to `window`, each holding a reference to a detached `bl-pagination` instance.

## What changed

- Store the resize handler as a stable bound class field (`_handleResize`) so `addEventListener`/`removeEventListener` target the exact same reference.
- Added a regression test that spies on `window.addEventListener`/`removeEventListener`, captures the handler passed on connect, and asserts `disconnectedCallback` removes that same reference.

## Why

Addresses the `bl-pagination` item in #1214's checklist:
> Fix the memory leak caused by the resize listener (implement listener cleanup).

## Testing

- New test: verifies `removeEventListener` is called with the identical handler reference `addEventListener` used.
- Full suite passes locally (Chromium): 780/781, with the one pre-existing failure (`bl-select` Turkish-locale search test) confirmed unrelated and present on `next` before this change.
- `tsc --noEmit`: clean.